### PR TITLE
Refactor: use Duration type instead of u64 to represent duration for …

### DIFF
--- a/src/constant.rs
+++ b/src/constant.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 // Default EVE Online API URLs
 /// Default EVE Online ESI URL
 pub static DEFAULT_ESI_URL: &str = "https://esi.evetech.net";
@@ -9,17 +11,17 @@ pub static DEFAULT_TOKEN_URL: &str = "https://login.eveonline.com/v2/oauth/token
 pub static DEFAULT_JWK_URL: &str = "https://login.eveonline.com/oauth/jwks";
 
 // Default JWT key cache settings
-/// Default JWT key cache lifetime before expiration in seconds (3600 seconds representing 1 hour)
-pub static DEFAULT_JWK_CACHE_TTL: u64 = 3600;
+/// Default JWT key cache lifetime before expiration (3600 seconds representing 1 hour)
+pub static DEFAULT_JWK_CACHE_TTL: Duration = Duration::from_secs(3600);
 // Default JWT key cache empty or expired cache settings
 /// Default maximum number of retries for JWT key refresh when cache is empty or expired (2 retries)
-pub static DEFAULT_JWK_REFRESH_MAX_RETRIES: u64 = 2;
-/// Default backoff period in seconds after a JWT key refresh failure when cache is empty or expired (100 milliseconds)
-pub static DEFAULT_JWK_REFRESH_BACKOFF: u64 = 100;
-/// Default timeout in seconds when waiting for another thread to refresh JWT key (5 seconds)
-pub static DEFAULT_JWK_REFRESH_TIMEOUT: u64 = 5;
-/// Default cooldown period in seconds after a failed set of JWT key refresh attempts (default 60 seconds)
-pub static DEFAULT_JWK_REFRESH_COOLDOWN: u64 = 60;
+pub static DEFAULT_JWK_REFRESH_MAX_RETRIES: u32 = 2;
+/// Default backoff period after a JWT key refresh failure when cache is empty or expired (100 milliseconds)
+pub static DEFAULT_JWK_REFRESH_BACKOFF: Duration = Duration::from_millis(100);
+/// Default timeout when waiting for another thread to refresh JWT key (5 seconds)
+pub static DEFAULT_JWK_REFRESH_TIMEOUT: Duration = Duration::from_secs(5);
+/// Default cooldown period after a failed set of JWT key refresh attempts (default 60 seconds)
+pub static DEFAULT_JWK_REFRESH_COOLDOWN: Duration = Duration::from_secs(60);
 
 // Default JWT key cache background refresh settings
 /// Default percentage of JWK_CACHE_TTL for when the background JWT key refresh is triggered (80%)

--- a/src/oauth2/jwk/cache.rs
+++ b/src/oauth2/jwk/cache.rs
@@ -14,8 +14,8 @@
 //! For details, see the [`JwtKeyCache`] struct.
 //! For a higher level overview of the usage of JWT keys, see [module-level documentation](super)
 
-use std::sync::atomic::AtomicBool;
 use std::time::Instant;
+use std::{sync::atomic::AtomicBool, time::Duration};
 
 use log::{debug, trace};
 use tokio::sync::{Notify, RwLock};
@@ -39,20 +39,20 @@ use crate::{
 #[derive(Clone)]
 pub(crate) struct JwtKeyCacheConfig {
     // Cache Settings
-    /// JWT key cache lifetime before expiration in seconds (3600 seconds representing 1 hour)
-    pub(crate) cache_ttl: u64,
+    /// JWT key cache lifetime before expiration (3600 seconds representing 1 hour)
+    pub(crate) cache_ttl: Duration,
 
     // Refresh Settings
     /// JSON web token key URL that provides keys used to validate tokens
     pub(crate) jwk_url: String,
+    /// Backoff period after a JWT key refresh failure when cache is empty or expired (default 100 milliseconds)
+    pub(crate) refresh_backoff: Duration,
+    /// Timeout when waiting for another thread to refresh JWT key (default 5 seconds)
+    pub(crate) refresh_timeout: Duration,
+    /// Cooldown period after a failed set of JWT key refresh attempts (default 60 seconds)
+    pub(crate) refresh_cooldown: Duration,
     /// Maximum number of retries for JWT key refresh when cache is empty or expired (default 2 retries)
-    pub(crate) refresh_max_retries: u64,
-    /// Backoff period in seconds after a JWT key refresh failure when cache is empty or expired (default 100 milliseconds)
-    pub(crate) refresh_backoff: u64,
-    /// Timeout in seconds when waiting for another thread to refresh JWT key (default 5 seconds)
-    pub(crate) refresh_timeout: u64,
-    /// Cooldown period in seconds after a failed set of JWT key refresh attempts (default 60 seconds)
-    pub(crate) refresh_cooldown: u64,
+    pub(crate) refresh_max_retries: u32,
 
     // Background Refresh Settings
     /// Determines whether or not a background task is spawned to refresh JWT keys proactively when cache is nearing expiration

--- a/src/oauth2/jwk/jwk.rs
+++ b/src/oauth2/jwk/jwk.rs
@@ -143,7 +143,7 @@ impl<'a> JwkApi<'a> {
         if let Some(cooldown_remaining) = cooldown {
             let error_message = format!(
                 "JWT key refresh cooldown still active due to recent refresh failure during last {} seconds. Cooldown remaining: {} seconds.",
-                &config.refresh_cooldown, cooldown_remaining
+                &config.refresh_cooldown.as_secs(), cooldown_remaining
             );
 
             #[cfg(not(tarpaulin_include))]

--- a/src/oauth2/jwk/refresh.rs
+++ b/src/oauth2/jwk/refresh.rs
@@ -64,7 +64,7 @@ impl<'a> JwkApi<'a> {
         #[cfg(not(tarpaulin_include))]
         trace!("Created notification future for JWT key refresh wait");
 
-        let refresh_timeout = Duration::from_secs(config.refresh_timeout);
+        let refresh_timeout = config.refresh_timeout;
         let refresh_success = tokio::select! {
             _ = notify_future => {true}
             _ = tokio::time::sleep(refresh_timeout) => {false}
@@ -91,7 +91,7 @@ impl<'a> JwkApi<'a> {
         if let Some((keys, timestamp)) = jwt_key_cache.get_keys().await {
             // Ensure keys are not expired
             let elapsed_seconds = timestamp.elapsed().as_secs();
-            if elapsed_seconds < config.cache_ttl {
+            if elapsed_seconds < config.cache_ttl.as_secs() {
                 #[cfg(not(tarpaulin_include))]
                 debug!(
                     "Successfully retrieved JWT keys from cache after waiting {}ms for refresh",
@@ -211,9 +211,7 @@ impl<'a> JwkApi<'a> {
 /// # Arguments
 /// - `reqwest_client` (&[`reqwest::Client`]): Client used for making HTTP requests
 /// - `jwt_key_cache` (&[`JwtKeyCache`]): Cache providing methods to get, update, and coordinate JWT key refreshes
-/// - `jwk_url` (&[`str`]): URL endpoint to retrieve the JWT keys from
-/// - `backoff` ([`u64`]): The exponential backoff in ms between request attempts
-/// - `max_retries` ([`u64`]): The amount of retries to make if the first attempt fails
+/// - `max_retries` ([`u32`]): The amount of retries to make if the first attempt fails
 ///
 /// # Returns
 /// - `Ok(`[`EveJwtKeys`]`)` if keys were successfully fetched and cached
@@ -221,7 +219,7 @@ impl<'a> JwkApi<'a> {
 pub(super) async fn refresh_jwt_keys(
     reqwest_client: &reqwest::Client,
     jwt_key_cache: &JwtKeyCache,
-    max_retries: u64,
+    max_retries: u32,
 ) -> Result<EveJwtKeys, EsiError> {
     let config = &jwt_key_cache.config;
 
@@ -241,7 +239,7 @@ pub(super) async fn refresh_jwt_keys(
             // Calculate exponential backoff duration:
             // Initial backoff (100ms default) multiplied by 2^retry_attempts
             // This causes wait time to double with each retry attempt
-            config.refresh_backoff * 2u64.pow(retry_attempts as u32),
+            config.refresh_backoff.as_millis() as u64 * 2u64.pow(retry_attempts),
         );
 
         #[cfg(not(tarpaulin_include))]
@@ -295,7 +293,7 @@ pub(super) async fn refresh_jwt_keys(
                 "JWT key refresh failed after {}ms: attempts={}, backoff_period={}ms, error={:?}",
                 elapsed.as_millis(),
                 retry_attempts,
-                config.refresh_backoff,
+                config.refresh_backoff.as_millis(),
                 err
             );
 

--- a/tests/oauth2/jwk/util.rs
+++ b/tests/oauth2/jwk/util.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use eve_esi::config::EsiConfig;
 use eve_esi::model::oauth2::EveJwtKeys;
 use eve_esi::EsiClient;
@@ -22,10 +24,10 @@ pub(super) async fn setup() -> (EsiClient, ServerGuard) {
     // Create a config with mock server JWK URL & reduced wait times
     let config = EsiConfig::builder()
         .jwk_url(&format!("{}/oauth/jwks", mock_server_url))
-        // Set expoential backoff between refresh retries to 1 millisecond
-        .jwk_refresh_backoff(1)
+        // Set exponential backoff between refresh retries to 1 millisecond
+        .jwk_refresh_backoff(Duration::from_millis(1))
         // Set timeout to 1 second when waiting for another thread to refresh
-        .jwk_refresh_timeout(1)
+        .jwk_refresh_timeout(Duration::from_secs(1))
         .build()
         .expect("Failed to build EsiConfig");
 


### PR DESCRIPTION
Refactors the following fields to use `std::time::Duration` instead of `u64` to represent a length of time

JwtKeyCacheConfig:
- refresh_backoff
- refresh_timeout
- refresh_cooldown

Additionally, `refresh_max_retries` has been changed to `u32` as `u64` was unnecessary.

Relevant documentation & functions have been updated to reflect the updated types. Code coverage remains unchanged after the refactor. The order of JwtKeyCacheConfig fields was slightly modified to put `refresh_max_retries` before the background settings and after the duration based settings.