### PR TITLE
Remove esi prefix from pub structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,15 @@ Rust API wrapper for interaction with [EVE Online's ESI](https://developers.eveo
 
 ## Usage
 
-Create a new EsiClient instance and request public information about a character from ESI.
+Create a new Client instance and request public information about a character from ESI.
 
 ```rust
 #[tokio::main]
 async fn main() {
-    let esi_client = eve_esi::EsiClient::builder()
+    let esi_client = eve_esi::Client::builder()
         .user_agent("MyApp/1.0 (contact@example.com)")
         .build()
-        .expect("Failed to build EsiClient");
+        .expect("Failed to build Client");
 
     // Get information about the corporation The Order of Autumn (id: 98785281)
     let corporation = esi_client.corporation().get_corporation_information(98785281).await.unwrap();
@@ -66,13 +66,8 @@ applications using this library should initialize a logger implementation like `
 env_logger::init();
 
 // Now logs from eve_esi will be captured
-let esi_client = eve_esi::EsiClient::builder()
+let esi_client = eve_esi::Client::builder()
     .user_agent("MyApp/1.0 (contact@example.com)")
     .build()
-    .expect("Failed to build EsiClient");
+    .expect("Failed to build Client");
 ```
-
-## Notes
-
-- More ESI routes will be added as needed, feel free to submit pull requests to add any you may need.
-- You can override the esi_url for the ESI Client by simply using `esi_client.esi_url = "http://your_url.com"` for use cases such as unit tests with crates such as [mockito](https://docs.rs/mockito/latest/mockito/) to emulate endpoints. See this repository's tests folder for examples.

--- a/examples/axum.rs
+++ b/examples/axum.rs
@@ -24,7 +24,7 @@ async fn main() {
         env!("CARGO_PKG_VERSION"),
         env!("CARGO_PKG_REPOSITORY")
     );
-    let esi_client: eve_esi::EsiClient = eve_esi::EsiClient::builder()
+    let esi_client: eve_esi::Client = eve_esi::Client::builder()
         .user_agent(&user_agent)
         .build()
         .expect("Failed to build ESI client");
@@ -48,7 +48,7 @@ async fn main() {
 }
 
 async fn get_esi_character(
-    Extension(esi_client): Extension<Arc<eve_esi::EsiClient>>,
+    Extension(esi_client): Extension<Arc<eve_esi::Client>>,
     params: Query<GetByIdParams>,
 ) -> Response {
     let character_id: i32 = params.0.id;
@@ -73,7 +73,7 @@ async fn get_esi_character(
 }
 
 async fn get_esi_corporation(
-    Extension(esi_client): Extension<Arc<eve_esi::EsiClient>>,
+    Extension(esi_client): Extension<Arc<eve_esi::Client>>,
     params: Query<GetByIdParams>,
 ) -> Response {
     let corporation_id: i32 = params.0.id;

--- a/examples/axum.rs
+++ b/examples/axum.rs
@@ -61,7 +61,7 @@ async fn get_esi_character(
         Ok(character) => (StatusCode::OK, Json(character)).into_response(),
         Err(error) => {
             let status_code: StatusCode = match &error {
-                eve_esi::error::EsiError::ReqwestError(ref err) => {
+                eve_esi::Error::ReqwestError(ref err) => {
                     StatusCode::from_u16(err.status().unwrap().into()).unwrap()
                 }
                 _ => StatusCode::INTERNAL_SERVER_ERROR,
@@ -86,7 +86,7 @@ async fn get_esi_corporation(
         Ok(corporation) => (StatusCode::OK, Json(corporation)).into_response(),
         Err(error) => {
             let status_code: StatusCode = match &error {
-                eve_esi::error::EsiError::ReqwestError(ref err) => {
+                eve_esi::Error::ReqwestError(ref err) => {
                     StatusCode::from_u16(err.status().unwrap().into()).unwrap()
                 }
                 _ => StatusCode::INTERNAL_SERVER_ERROR,

--- a/examples/sso.rs
+++ b/examples/sso.rs
@@ -30,13 +30,13 @@ async fn main() {
         contact_email,
         env!("CARGO_PKG_REPOSITORY")
     );
-    let esi_client: eve_esi::EsiClient = eve_esi::EsiClient::builder()
+    let esi_client: eve_esi::Client = eve_esi::Client::builder()
         .user_agent(&user_agent)
         .client_id(&esi_client_id)
         .client_secret(&esi_secret_secret)
         .callback_url(&callback_url)
         .build()
-        .expect("Failed to build EsiClient");
+        .expect("Failed to build Client");
 
     // Arc is used to share the client between threads safely
     // Sharing the esi_client as an Extension avoids having initialize it in every API route
@@ -54,7 +54,7 @@ async fn main() {
     axum::serve(listener, app).await.unwrap();
 }
 
-async fn login(Extension(esi_client): Extension<Arc<eve_esi::EsiClient>>) -> Response {
+async fn login(Extension(esi_client): Extension<Arc<eve_esi::Client>>) -> Response {
     let scopes = eve_esi::oauth2::ScopeBuilder::new().public_data().build();
 
     let auth_data = match esi_client.oauth2().login_url(scopes) {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,8 +1,8 @@
 //! # EVE Online ESI Client Builder
 //!
-//! This module provides the [`EsiClient`] struct for interacting with the EVE Online ESI (EVE Stable Infrastructure) API.
+//! This module provides the [`Client`] struct for interacting with the EVE Online ESI (EVE Stable Infrastructure) API.
 //!
-//! For details on the usage of an [`EsiClient`], see the [client module docs](crate::client).
+//! For details on the usage of an [`Client`], see the [client module docs](crate::client).
 //!
 //! ## References
 //! - [ESI API Documentation](https://developers.eveonline.com/api-explorer)
@@ -10,15 +10,15 @@
 //!
 //! ## Features
 //! - Set a user agent
-//! - Configure [`EsiClient`] for OAuth2 using `client_id`, `client_secret`, and `callback_url` methods
+//! - Configure [`Client`] for OAuth2 using `client_id`, `client_secret`, and `callback_url` methods
 //! - Override the default JWT key cache & refresh settings used to validate OAuth2 tokens & override
-//!   the default endpoint URLs with a custom [`EsiConfig`] using the [`EsiClientBuilder::config`] method.
+//!   the default endpoint URLs with a custom [`EsiConfig`] using the [`ClientBuilder::config`] method.
 //!
 //! ## Builder Methods
 //! | Method           | Purpose                                 |
 //! | ---------------- | --------------------------------------- |
-//! | `new`            | Create a builder for the EsiClient      |
-//! | `build`          | Build the EsiClient                     |
+//! | `new`            | Create a builder for the Client      |
+//! | `build`          | Build the Client                     |
 //! | `config`         | Override the default config             |
 //! | `reqwest_client` | Override default reqwest client         |
 //! | `user_agent`     | User agent to identify HTTP requests    |
@@ -28,13 +28,13 @@
 //!
 //! ## Usage
 //! ```
-//! use eve_esi::EsiClient;
+//! use eve_esi::Client;
 //!
 //! // Set a user agent used to identify the application making ESI requests
-//! let esi_client = EsiClient::builder()
+//! let esi_client = Client::builder()
 //!     .user_agent("MyApp/1.0 (contact@example.com)")
 //!     .build()
-//!     .expect("Failed to build EsiClient");
+//!     .expect("Failed to build Client");
 //! ```
 //!
 //! ## Warning
@@ -50,12 +50,12 @@ use log::warn;
 use crate::config::EsiConfig;
 use crate::error::Error;
 use crate::oauth2::jwk::cache::JwtKeyCache;
-use crate::EsiClient;
+use crate::Client;
 
-/// Builder for configuring and constructing an [`EsiClient`].
+/// Builder for configuring and constructing an [`Client`].
 ///
 /// For a full overview, features, and usage examples, see the [module-level documentation](self).
-pub struct EsiClientBuilder {
+pub struct ClientBuilder {
     // Base Settings
     /// Config used to override default settings
     pub(crate) config: Option<EsiConfig>,
@@ -73,13 +73,13 @@ pub struct EsiClientBuilder {
     pub(crate) callback_url: Option<String>,
 }
 
-impl EsiClientBuilder {
-    /// Creates a new [`EsiClientBuilder`]
+impl ClientBuilder {
+    /// Creates a new [`ClientBuilder`]
     ///
     /// For a full overview, features, and usage examples, see the [module-level documentation](self).
     ///
     /// # Returns
-    /// - [`EsiClientBuilder`]: Instance to modify EsiClient setting using setter methods
+    /// - [`ClientBuilder`]: Instance to modify Client setting using setter methods
     pub fn new() -> Self {
         Self {
             // Base settings
@@ -94,20 +94,20 @@ impl EsiClientBuilder {
         }
     }
 
-    /// Builds the EsiClient
+    /// Builds the Client
     ///
     /// For a full overview, features, and usage examples, see the [module-level documentation](self).
     ///
     /// # Returns
-    /// - [`EsiClient`]: Instance to interface with EVE Online ESI & OAuth2 endpoints.
+    /// - [`Client`]: Instance to interface with EVE Online ESI & OAuth2 endpoints.
     ///
     /// # Error
     /// Returns an [`EsiError`] if:
     /// - There is a user issue related to building an [`oauth2::Client`] usually due to
-    ///   missing OAuth2 settings on [`EsiClientBuilder`] or invalid URLs configured by a custom [`EsiConfig`].
+    ///   missing OAuth2 settings on [`ClientBuilder`] or invalid URLs configured by a custom [`EsiConfig`].
     /// - There is an internal issue building a default [`reqwest::Client`]
     /// - There is an internal issue building a default [`EsiConfig`]
-    pub fn build(self) -> Result<EsiClient, Error> {
+    pub fn build(self) -> Result<Client, Error> {
         let mut builder = self;
 
         // Create a default EsiConfig if one is not provided
@@ -137,8 +137,8 @@ impl EsiClientBuilder {
         // Setup JWT key cache
         let jwt_key_cache = JwtKeyCache::new(&config);
 
-        // Build EsiClient
-        Ok(EsiClient {
+        // Build Client
+        Ok(Client {
             reqwest_client,
             esi_url: config.esi_url,
 
@@ -148,31 +148,31 @@ impl EsiClientBuilder {
         })
     }
 
-    /// Overrides the default [`EsiClient`] settings with a custom config
+    /// Overrides the default [`Client`] settings with a custom config
     ///
-    /// If no config is provided to the [`EsiClientBuilder`], the default settings will be used.
+    /// If no config is provided to the [`ClientBuilder`], the default settings will be used.
     /// This method allows one to provide a config to override the default settings, for details
     /// on usage & options see the [config module documentation](super::config).
     ///
     /// # Arguments
-    /// - `config` ([`EsiConfig`]): config used to override default [`EsiClient`] settings
+    /// - `config` ([`EsiConfig`]): config used to override default [`Client`] settings
     ///
     /// # Returns
-    /// - [`EsiClientBuilder`]: instance with the updated config
+    /// - [`ClientBuilder`]: instance with the updated config
     pub fn config(mut self, config: EsiConfig) -> Self {
         self.config = Some(config);
         self
     }
 
-    /// Override the default [`reqwest::Client`] used by [`EsiClient`]
+    /// Override the default [`reqwest::Client`] used by [`Client`]
     ///
-    /// Use this to configure the HTTP client used by [`EsiClient`] with your
+    /// Use this to configure the HTTP client used by [`Client`] with your
     /// own preferred settings.
     ///
     /// You can create and configure a reqwest client using the [`reqwest::Client::builder`] method.
     ///
     /// # Warning
-    /// The [`EsiClientBuilder::user_agent`] method will not be applied in the
+    /// The [`ClientBuilder::user_agent`] method will not be applied in the
     /// event that a custom reqwest client is provided, instead you should
     /// set the user agent on the provided [`reqwest::Client`] prior to calling
     /// this method.
@@ -182,16 +182,16 @@ impl EsiClientBuilder {
     ///   EVE Online's API endpoints.
     ///
     /// # Returns
-    /// - [EsiClientBuilder]: Instance with the configured reqwest client
+    /// - [ClientBuilder]: Instance with the configured reqwest client
     pub fn reqwest_client(mut self, client: reqwest::Client) -> Self {
         self.reqwest_client = Some(client);
         self
     }
 
-    /// Sets the user agent for the EsiClient.
+    /// Sets the user agent for the Client.
     ///
     /// This method configures the user agent string used by the default reqwest HTTP client created by
-    /// the [`EsiClient`] if a custom reqwest client is not provided with the [`Self::reqwest_client`]
+    /// the [`Client`] if a custom reqwest client is not provided with the [`Self::reqwest_client`]
     /// method.
     ///
     /// The user agent string is used to identify the client making requests to the EVE Online API.
@@ -210,7 +210,7 @@ impl EsiClientBuilder {
     /// - `user_agent` ([`String`]): user agent string to be used by the reqwest HTTP client.
     ///
     /// # Returns
-    /// - [`EsiClientBuilder`]: instance with updated user agent configuration.
+    /// - [`ClientBuilder`]: instance with updated user agent configuration.
     pub fn user_agent(mut self, user_agent: &str) -> Self {
         self.user_agent = Some(user_agent.to_string());
         self
@@ -229,7 +229,7 @@ impl EsiClientBuilder {
     /// - `client_id` ([`String`]): The OAuth2 client ID obtained from the EVE Online developer portal.
     ///
     /// # Returns
-    /// - [`EsiClientBuilder`]: instance with updated client ID configuration.
+    /// - [`ClientBuilder`]: instance with updated client ID configuration.
     pub fn client_id(mut self, client_id: &str) -> Self {
         self.client_id = Some(client_id.to_string());
         self
@@ -248,7 +248,7 @@ impl EsiClientBuilder {
     /// - `client_secret` ([`String`]): The OAuth2 client secret obtained from the EVE Online developer portal.
     ///
     /// # Returns
-    /// - [`EsiClientBuilder`]: instance with updated client secret configuration.
+    /// - [`ClientBuilder`]: instance with updated client secret configuration.
     pub fn client_secret(mut self, client_secret: &str) -> Self {
         self.client_secret = Some(client_secret.to_string());
         self
@@ -267,7 +267,7 @@ impl EsiClientBuilder {
     /// - `callback_url` ([`String`]): The callback URL which matches the one set in your EVE Online developer portal application.
     ///
     /// # Returns
-    /// - [`EsiClientBuilder`] instance with updated callback URL configuration.
+    /// - [`ClientBuilder`] instance with updated callback URL configuration.
     pub fn callback_url(mut self, callback_url: &str) -> Self {
         self.callback_url = Some(callback_url.to_string());
         self
@@ -276,7 +276,7 @@ impl EsiClientBuilder {
 
 /// Utility function that creates a default [`reqwest::Client`] if no client is provided
 ///
-/// Used with the [`EsiClientBuilder::build`] method to create a default [`reqwest::Client`] with
+/// Used with the [`ClientBuilder::build`] method to create a default [`reqwest::Client`] with
 /// provided user agent if a reqwest custom client has not been provided.
 ///
 /// Provides a warning if both a custom agent and user agent has been provided as the user agent
@@ -302,7 +302,7 @@ fn get_or_default_reqwest_client(
         Some(client) => {
             if user_agent.is_some() {
                 #[cfg(not(tarpaulin_include))]
-                warn!("user_agent is set on `EsiClientBuilder` but so is reqwest_client, as a result the user_agent will not be applied and should be instead applied to the provided reqwest client if not done so already.");
+                warn!("user_agent is set on `ClientBuilder` but so is reqwest_client, as a result the user_agent will not be applied and should be instead applied to the provided reqwest client if not done so already.");
             }
 
             Ok(client)
@@ -323,17 +323,17 @@ mod tests {
     use super::*;
     use crate::{constant::DEFAULT_ESI_URL, ConfigError};
 
-    /// Test default values of the `EsiClientBuilder`.
+    /// Test default values of the `ClientBuilder`.
     ///
     /// # Setup
-    /// - Create an [`EsiClientBuilder`] with the default values
+    /// - Create an [`ClientBuilder`] with the default values
     ///
     /// # Assertions
     /// - Assert default values are set as expected
     #[test]
     fn test_default_builder_values() {
-        // Create an EsiClientBuilder with the default values
-        let builder = EsiClientBuilder::new();
+        // Create an ClientBuilder with the default values
+        let builder = ClientBuilder::new();
 
         // Assert default values are set as expected
         assert!(builder.config.is_none());
@@ -344,12 +344,12 @@ mod tests {
         assert!(builder.callback_url.is_none());
     }
 
-    /// Test setter methods of the [`EsiClientBuilder`].
+    /// Test setter methods of the [`ClientBuilder`].
     ///
     /// # Setup
     /// - Create a custom [`reqwest::Client`]
     /// - Create a custom [`JwtKeyCache`]
-    /// - Creates an [`EsiClient`] with all builder setter methods used
+    /// - Creates an [`Client`] with all builder setter methods used
     ///
     /// # Assertions
     /// - Assert base settings are set as expected
@@ -359,7 +359,7 @@ mod tests {
         let custom_reqwest_client = reqwest::Client::new();
         let custom_config = EsiConfig::new().expect("Failed to create a default EsiConfig");
 
-        let builder = EsiClientBuilder::new()
+        let builder = ClientBuilder::new()
             // Base settings
             .config(custom_config)
             .user_agent("MyApp/1.0 (contact@example.com)")
@@ -396,7 +396,7 @@ mod tests {
     #[test]
     fn test_successful_build_minimal() {
         // Test building with just the required user_agent
-        let result = EsiClientBuilder::new()
+        let result = ClientBuilder::new()
             .user_agent("MyApp/1.0 (contact@example.com)")
             .build();
 
@@ -420,7 +420,7 @@ mod tests {
     #[test]
     fn test_successful_build_with_oauth() {
         // Test building with OAuth configuration
-        let result = EsiClientBuilder::new()
+        let result = ClientBuilder::new()
             .user_agent("MyApp/1.0 (contact@example.com)")
             .client_id("client_id")
             .client_secret("client_secret")
@@ -452,10 +452,10 @@ mod tests {
             .expect("Failed to create a default EsiConfig");
 
         // Create an ESI client with the custom config
-        let result = EsiClientBuilder::new()
+        let result = ClientBuilder::new()
             .config(config)
             .build()
-            .expect("Failed to build EsiClient");
+            .expect("Failed to build Client");
 
         // Assert default ESI URL has been overridden
         assert_ne!(result.esi_url, DEFAULT_ESI_URL);
@@ -471,7 +471,7 @@ mod tests {
     #[test]
     fn test_build_with_partial_oauth_config() {
         // Test that providing only client_id without the other OAuth params fails
-        let result = EsiClientBuilder::new()
+        let result = ClientBuilder::new()
             .user_agent("MyApp/1.0 (contact@example.com)")
             .client_id("client_id")
             .build();

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -12,7 +12,7 @@
 //! - Set a user agent
 //! - Configure [`Client`] for OAuth2 using `client_id`, `client_secret`, and `callback_url` methods
 //! - Override the default JWT key cache & refresh settings used to validate OAuth2 tokens & override
-//!   the default endpoint URLs with a custom [`EsiConfig`] using the [`ClientBuilder::config`] method.
+//!   the default endpoint URLs with a custom [`Config`] using the [`ClientBuilder::config`] method.
 //!
 //! ## Builder Methods
 //! | Method           | Purpose                                 |
@@ -47,7 +47,7 @@ use std::sync::Arc;
 
 use log::warn;
 
-use crate::config::EsiConfig;
+use crate::config::Config;
 use crate::error::Error;
 use crate::oauth2::jwk::cache::JwtKeyCache;
 use crate::Client;
@@ -58,7 +58,7 @@ use crate::Client;
 pub struct ClientBuilder {
     // Base Settings
     /// Config used to override default settings
-    pub(crate) config: Option<EsiConfig>,
+    pub(crate) config: Option<Config>,
     /// Overrides the default reqwest HTTP client if set to Some()
     pub(crate) reqwest_client: Option<reqwest::Client>,
     /// User agent used for default reqwest client if no client is provided
@@ -104,16 +104,16 @@ impl ClientBuilder {
     /// # Error
     /// Returns an [`EsiError`] if:
     /// - There is a user issue related to building an [`oauth2::Client`] usually due to
-    ///   missing OAuth2 settings on [`ClientBuilder`] or invalid URLs configured by a custom [`EsiConfig`].
+    ///   missing OAuth2 settings on [`ClientBuilder`] or invalid URLs configured by a custom [`Config`].
     /// - There is an internal issue building a default [`reqwest::Client`]
-    /// - There is an internal issue building a default [`EsiConfig`]
+    /// - There is an internal issue building a default [`Config`]
     pub fn build(self) -> Result<Client, Error> {
         let mut builder = self;
 
-        // Create a default EsiConfig if one is not provided
+        // Create a default Config if one is not provided
         let config = match builder.config.take() {
             Some(config) => config,
-            None => EsiConfig::new()?,
+            None => Config::new()?,
         };
 
         // Setup a reqwest client
@@ -155,11 +155,11 @@ impl ClientBuilder {
     /// on usage & options see the [config module documentation](super::config).
     ///
     /// # Arguments
-    /// - `config` ([`EsiConfig`]): config used to override default [`Client`] settings
+    /// - `config` ([`Config`]): config used to override default [`Client`] settings
     ///
     /// # Returns
     /// - [`ClientBuilder`]: instance with the updated config
-    pub fn config(mut self, config: EsiConfig) -> Self {
+    pub fn config(mut self, config: Config) -> Self {
         self.config = Some(config);
         self
     }
@@ -357,7 +357,7 @@ mod tests {
     #[test]
     fn test_builder_setter_methods() {
         let custom_reqwest_client = reqwest::Client::new();
-        let custom_config = EsiConfig::new().expect("Failed to create a default EsiConfig");
+        let custom_config = Config::new().expect("Failed to create a default Config");
 
         let builder = ClientBuilder::new()
             // Base settings
@@ -446,10 +446,10 @@ mod tests {
     #[test]
     fn test_build_with_custom_config() {
         // Create a config overriding default ESI URL
-        let config = EsiConfig::builder()
+        let config = Config::builder()
             .esi_url("https://example.com")
             .build()
-            .expect("Failed to create a default EsiConfig");
+            .expect("Failed to create a default Config");
 
         // Create an ESI client with the custom config
         let result = ClientBuilder::new()
@@ -467,7 +467,7 @@ mod tests {
     /// - Creates an ESI client builder with only the client_id set.
     ///
     /// # Assertions
-    /// - Verifies that the error response is EsiConfigError::MissingClientSecret
+    /// - Verifies that the error response is ConfigError::MissingClientSecret
     #[test]
     fn test_build_with_partial_oauth_config() {
         // Test that providing only client_id without the other OAuth params fails

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -48,7 +48,7 @@ use std::sync::Arc;
 use log::warn;
 
 use crate::config::EsiConfig;
-use crate::error::EsiError;
+use crate::error::Error;
 use crate::oauth2::jwk::cache::JwtKeyCache;
 use crate::EsiClient;
 
@@ -107,7 +107,7 @@ impl EsiClientBuilder {
     ///   missing OAuth2 settings on [`EsiClientBuilder`] or invalid URLs configured by a custom [`EsiConfig`].
     /// - There is an internal issue building a default [`reqwest::Client`]
     /// - There is an internal issue building a default [`EsiConfig`]
-    pub fn build(self) -> Result<EsiClient, EsiError> {
+    pub fn build(self) -> Result<EsiClient, Error> {
         let mut builder = self;
 
         // Create a default EsiConfig if one is not provided
@@ -297,7 +297,7 @@ impl EsiClientBuilder {
 fn get_or_default_reqwest_client(
     client: Option<reqwest::Client>,
     user_agent: &Option<String>,
-) -> Result<reqwest::Client, EsiError> {
+) -> Result<reqwest::Client, Error> {
     match client {
         Some(client) => {
             if user_agent.is_some() {
@@ -321,7 +321,7 @@ fn get_or_default_reqwest_client(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{constant::DEFAULT_ESI_URL, error::EsiConfigError};
+    use crate::{constant::DEFAULT_ESI_URL, ConfigError};
 
     /// Test default values of the `EsiClientBuilder`.
     ///
@@ -478,7 +478,7 @@ mod tests {
 
         assert!(result.is_err());
         match result {
-            Err(EsiError::EsiConfigError(EsiConfigError::MissingClientSecret)) => {}
+            Err(Error::ConfigError(ConfigError::MissingClientSecret)) => {}
             _ => panic!("Expected MissingClientSecret error"),
         }
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,6 +1,6 @@
 //! # EVE Online ESI Client
 //!
-//! This module provides the [`EsiClient`] struct for interacting with EVE Online's ESI (EVE Stable Infrastructure) API.
+//! This module provides the [`Client`] struct for interacting with EVE Online's ESI (EVE Stable Infrastructure) API.
 //!
 //! ## Features
 //! - Make authenticated and unauthenticated requests to ESI endpoints
@@ -15,13 +15,11 @@
 //!
 //! ## Example
 //! ```
-//! use eve_esi::EsiClient;
-//!
 //! // Set a user agent used to identify the application making ESI requests
-//! let esi_client = EsiClient::builder()
+//! let esi_client = eve_esi::Client::builder()
 //!     .user_agent("MyApp/1.0 (contact@example.com)")
 //!     .build()
-//!     .expect("Failed to build EsiClient");
+//!     .expect("Failed to build Client");
 //! ```
 //!
 //! ## Warning
@@ -32,7 +30,7 @@
 
 use std::sync::Arc;
 
-use crate::builder::EsiClientBuilder;
+use crate::builder::ClientBuilder;
 use crate::oauth2::client::OAuth2Client;
 use crate::oauth2::jwk::cache::JwtKeyCache;
 
@@ -41,7 +39,7 @@ use crate::oauth2::jwk::cache::JwtKeyCache;
 /// Use this struct to configure OAuth2 authentication and make requests to ESI endpoints.
 ///
 /// For a full overview, features, and usage examples, see the [module-level documentation](self).
-pub struct EsiClient {
+pub struct Client {
     // Base settings
     /// HTTP client used to make requests to EVE Online's APIs
     pub(crate) reqwest_client: reqwest::Client,
@@ -52,19 +50,19 @@ pub struct EsiClient {
     /// OAuth2 client used for accessing EVE Online OAuth2 endpoints
     ///
     /// Will be None if `client_id`, `client_secret`, and `callback_url` have not been
-    /// set on the [`EsiClient`] which will result in errors if trying to use OAuth2-related endpoints.
+    /// set on the [`Client`] which will result in errors if trying to use OAuth2-related endpoints.
     pub(crate) oauth2_client: Option<OAuth2Client>,
     /// Cache containing JWT keys for validating OAuth2 tokens and fields for coordinating
     /// cache usage & refreshes across threads.
     pub(crate) jwt_key_cache: Arc<JwtKeyCache>,
 }
 
-impl EsiClient {
-    /// Creates a new [`EsiClientBuilder`]
+impl Client {
+    /// Creates a new [`ClientBuilder`]
     ///
     /// For a full overview, features, and usage examples, see the [module-level documentation](self).
-    pub fn builder() -> EsiClientBuilder {
-        EsiClientBuilder::new()
+    pub fn builder() -> ClientBuilder {
+        ClientBuilder::new()
     }
 }
 
@@ -72,18 +70,18 @@ impl EsiClient {
 mod tests {
     use super::*;
 
-    /// Test the successful minimal build of [`EsiClient::builder`]
+    /// Test the successful minimal build of [`Client::builder`]
     ///
     /// # Setup
-    /// - Setup an EsiClientBuilder using the builder() method
+    /// - Setup an ClientBuilder using the builder() method
     ///
     /// # Assertions
     /// - Validate that the default values are correct
     /// - Verify that the esi_client has built successfully
     #[test]
     fn test_successful_build_minimal() {
-        // Test that builder() returns a valid EsiClientBuilder
-        let builder = EsiClient::builder();
+        // Test that builder() returns a valid ClientBuilder
+        let builder = Client::builder();
 
         // Verify the builder has expected default values
         assert!(builder.user_agent.is_none());

--- a/src/config.rs
+++ b/src/config.rs
@@ -59,7 +59,7 @@ use oauth2::{AuthUrl, TokenUrl};
 
 use crate::{
     constant::{DEFAULT_AUTH_URL, DEFAULT_ESI_URL, DEFAULT_TOKEN_URL},
-    error::{EsiConfigError, EsiError},
+    error::{ConfigError, Error},
     oauth2::jwk::cache::JwtKeyCacheConfig,
 };
 
@@ -107,7 +107,7 @@ impl EsiConfig {
     ///
     /// # Errors
     /// - [`EsiError`]: If the default [`EsiConfigBuilder::jwk_background_refresh_threshold`] is configured incorrectly.
-    pub fn new() -> Result<Self, EsiError> {
+    pub fn new() -> Result<Self, Error> {
         EsiConfigBuilder::new().build()
     }
 
@@ -159,28 +159,28 @@ impl EsiConfigBuilder {
     /// - The [`Self::jwk_background_refresh_threshold`] method is given a value less than 1 or over 99
     /// - The [`Self::auth_url`] method is given an invalid URL
     /// - The [`Self::token_url`] method is given an invalid URL
-    pub fn build(self) -> Result<EsiConfig, EsiError> {
+    pub fn build(self) -> Result<EsiConfig, Error> {
         // Ensure background refresh percentage is set properly
         if !(self.jwt_key_cache_config.background_refresh_threshold > 0) {
-            return Err(EsiError::EsiConfigError(
-                EsiConfigError::InvalidBackgroundRefreshThreshold,
+            return Err(Error::ConfigError(
+                ConfigError::InvalidBackgroundRefreshThreshold,
             ));
         }
         if !(self.jwt_key_cache_config.background_refresh_threshold < 100) {
-            return Err(EsiError::EsiConfigError(
-                EsiConfigError::InvalidBackgroundRefreshThreshold,
+            return Err(Error::ConfigError(
+                ConfigError::InvalidBackgroundRefreshThreshold,
             ));
         }
 
         // Parse URLs
         let auth_url = match AuthUrl::new(self.auth_url.clone()) {
             Ok(url) => url,
-            Err(_) => return Err(EsiError::EsiConfigError(EsiConfigError::InvalidAuthUrl)),
+            Err(_) => return Err(Error::ConfigError(ConfigError::InvalidAuthUrl)),
         };
         let token_url = match TokenUrl::new(self.token_url.clone()) {
             Ok(url) => url,
             Err(_) => {
-                return Err(EsiError::EsiConfigError(EsiConfigError::InvalidTokenUrl));
+                return Err(Error::ConfigError(ConfigError::InvalidTokenUrl));
             }
         };
 
@@ -485,8 +485,8 @@ mod tests {
         // Assert error is of type OAuthConfigError::InvalidBackgroundRefreshThreshold
         assert!(matches!(
             result,
-            Err(EsiError::EsiConfigError(
-                EsiConfigError::InvalidBackgroundRefreshThreshold
+            Err(Error::ConfigError(
+                ConfigError::InvalidBackgroundRefreshThreshold
             ))
         ))
     }
@@ -512,8 +512,8 @@ mod tests {
         // Assert error is of type EsiConfigError::InvalidBackgroundRefreshThreshold
         assert!(matches!(
             result,
-            Err(EsiError::EsiConfigError(
-                EsiConfigError::InvalidBackgroundRefreshThreshold
+            Err(Error::ConfigError(
+                ConfigError::InvalidBackgroundRefreshThreshold
             ))
         ))
     }
@@ -535,7 +535,7 @@ mod tests {
 
         match result {
             // Assert error is of the EsiConfigError:InvalidAuthUrl variant
-            Err(EsiError::EsiConfigError(EsiConfigError::InvalidAuthUrl)) => {}
+            Err(Error::ConfigError(ConfigError::InvalidAuthUrl)) => {}
             _ => panic!("Expected InvalidAuthUrl error"),
         }
     }
@@ -557,7 +557,7 @@ mod tests {
 
         match result {
             // Assert error is of the EsiConfigError:InvalidTokenUrl variant
-            Err(EsiError::EsiConfigError(EsiConfigError::InvalidTokenUrl)) => {}
+            Err(Error::ConfigError(ConfigError::InvalidTokenUrl)) => {}
             _ => panic!("Expected InvalidTokenUrl error"),
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,8 +16,8 @@
 //!
 //! | Method          | Purpose                                    |
 //! | --------------- | ------------------------------------------ |
-//! | `new`           | Create a new [`EsiConfigBuilder`]          |
-//! | `build`         | Build the [`EsiConfig`]                    |
+//! | `new`           | Create a new [`ConfigBuilder`]          |
+//! | `build`         | Build the [`Config`]                    |
 //! | `esi_url`       | Base URL for ESI endpoints                 |
 //! | `auth_url`      | URL for sign in with EVE Online            |
 //! | `token_url`     | URL to retrieve access tokens for OAuth2   |
@@ -35,14 +35,14 @@
 //! ```
 //! use std::time::Duration;
 //!
-//! use eve_esi::config::EsiConfig;
+//! use eve_esi::config::Config;
 //!
 //! // Build a config to override defaults
-//! let config = EsiConfig::builder()
+//! let config = Config::builder()
 //!     // Set JWT key cache lifetime to 7200 seconds representing 2 hours
 //!     .jwk_cache_ttl(Duration::from_secs(7200))
 //!     .build()
-//!     .expect("Failed to build EsiConfig");
+//!     .expect("Failed to build Config");
 //!
 //! // Apply config settings to Client
 //! let esi_client = eve_esi::Client::builder()
@@ -65,7 +65,7 @@ use crate::{
 /// Configuration settings for the [`Client`](crate::Client)
 ///
 /// For a full overview, features, and usage examples, see the [module-level documentation](self).
-pub struct EsiConfig {
+pub struct Config {
     // URL settings
     /// The base EVE Online ESI API URL
     pub(crate) esi_url: String,
@@ -79,10 +79,10 @@ pub struct EsiConfig {
     pub(crate) jwt_key_cache_config: JwtKeyCacheConfig,
 }
 
-/// Builder struct for configuring & constructing an [`EsiConfig`] to override default [`Client`](crate::Client) settings
+/// Builder struct for configuring & constructing an [`Config`] to override default [`Client`](crate::Client) settings
 ///
 /// For a full overview, features, and usage examples, see the [module-level documentation](self).
-pub struct EsiConfigBuilder {
+pub struct ConfigBuilder {
     // URL settings
     /// The base EVE Online ESI API URL
     pub(crate) esi_url: String,
@@ -96,41 +96,41 @@ pub struct EsiConfigBuilder {
     pub(crate) jwt_key_cache_config: JwtKeyCacheConfig,
 }
 
-impl EsiConfig {
-    /// Creates a new instance of [`EsiConfig`] with default settings
+impl Config {
+    /// Creates a new instance of [`Config`] with default settings
     ///
     /// For details see [module-level documentation](self).
     ///
     /// # Returns
-    /// - [`EsiConfig`]: With the default configuration
+    /// - [`Config`]: With the default configuration
     ///
     /// # Errors
-    /// - [`EsiError`]: If the default [`EsiConfigBuilder::jwk_background_refresh_threshold`] is configured incorrectly.
+    /// - [`EsiError`]: If the default [`ConfigBuilder::jwk_background_refresh_threshold`] is configured incorrectly.
     pub fn new() -> Result<Self, Error> {
-        EsiConfigBuilder::new().build()
+        ConfigBuilder::new().build()
     }
 
-    /// Returns a [`EsiConfigBuilder`] instance used to configure JWT key related settings
+    /// Returns a [`ConfigBuilder`] instance used to configure JWT key related settings
     ///
-    /// Allows for the configuration of the [`EsiConfig`] using the [`EsiConfigBuilder`]
+    /// Allows for the configuration of the [`Config`] using the [`ConfigBuilder`]
     /// setter methods to override the default configuration.
     ///
     /// For details see [module-level documentation](self).
     ///
     /// # Returns
-    /// - [`EsiConfigBuilder`]: Instance with the default config which can be overridden with setter methods.
-    pub fn builder() -> EsiConfigBuilder {
-        EsiConfigBuilder::new()
+    /// - [`ConfigBuilder`]: Instance with the default config which can be overridden with setter methods.
+    pub fn builder() -> ConfigBuilder {
+        ConfigBuilder::new()
     }
 }
 
-impl EsiConfigBuilder {
-    /// Creates a new [`EsiConfigBuilder`] instance used to build an [`EsiConfig`]
+impl ConfigBuilder {
+    /// Creates a new [`ConfigBuilder`] instance used to build an [`Config`]
     ///
     /// For a full overview, features, and usage example, see the [module-level documentation](self).
     ///
     /// # Returns
-    /// - [`EsiConfigBuilder`]: Instance with the default settings that can be modified with the setter methods.
+    /// - [`ConfigBuilder`]: Instance with the default settings that can be modified with the setter methods.
     pub fn new() -> Self {
         Self {
             // URL settings
@@ -143,22 +143,22 @@ impl EsiConfigBuilder {
         }
     }
 
-    /// Builds a [`EsiConfig`] instance
+    /// Builds a [`Config`] instance
     ///
-    /// Converts an [`EsiConfigBuilder`] into a [`EsiConfig`] with the configured values that
+    /// Converts an [`ConfigBuilder`] into a [`Config`] with the configured values that
     /// were set with the builder methods.
     ///
     /// For a full overview, features, and usage example, see the [module-level documentation](self).
     ///
     /// # Returns
-    /// - [`EsiConfig`]: instance with the settings configured on the builder
+    /// - [`Config`]: instance with the settings configured on the builder
     ///
     /// # Errors
     /// Returns an [`EsiError`] if one of the following occurs:
     /// - The [`Self::jwk_background_refresh_threshold`] method is given a value less than 1 or over 99
     /// - The [`Self::auth_url`] method is given an invalid URL
     /// - The [`Self::token_url`] method is given an invalid URL
-    pub fn build(self) -> Result<EsiConfig, Error> {
+    pub fn build(self) -> Result<Config, Error> {
         // Ensure background refresh percentage is set properly
         if !(self.jwt_key_cache_config.background_refresh_threshold > 0) {
             return Err(Error::ConfigError(
@@ -183,7 +183,7 @@ impl EsiConfigBuilder {
             }
         };
 
-        Ok(EsiConfig {
+        Ok(Config {
             // URL settings
             esi_url: self.esi_url,
             auth_url: auth_url,
@@ -204,7 +204,7 @@ impl EsiConfigBuilder {
     /// - `esi_url` (&[`str`]): The EVE Online ESI API base URL.
     ///
     /// # Returns
-    /// - [`EsiConfigBuilder`]: Instance with the updated ESI URL
+    /// - [`ConfigBuilder`]: Instance with the updated ESI URL
     pub fn esi_url(mut self, esi_url: &str) -> Self {
         self.esi_url = esi_url.to_string();
         self
@@ -220,7 +220,7 @@ impl EsiConfigBuilder {
     /// - `auth_url` (&[`str`]): The EVE Online OAuth2 authorization endpoint URL.
     ///
     /// # Returns
-    /// - [`EsiConfigBuilder`]: Instance with updated EVE Online OAuth2 authorization URL.
+    /// - [`ConfigBuilder`]: Instance with updated EVE Online OAuth2 authorization URL.
     pub fn auth_url(mut self, auth_url: &str) -> Self {
         self.auth_url = auth_url.to_string();
         self
@@ -236,7 +236,7 @@ impl EsiConfigBuilder {
     /// - `token_url` (&[`str`]): The EVE Online OAuth2 token endpoint URL.
     ///
     /// # Returns
-    /// - [`EsiConfigBuilder`]: Instance with updated EVE Online OAuth2 token URL.
+    /// - [`ConfigBuilder`]: Instance with updated EVE Online OAuth2 token URL.
     pub fn token_url(mut self, token_url: &str) -> Self {
         self.token_url = token_url.to_string();
         self
@@ -252,7 +252,7 @@ impl EsiConfigBuilder {
     /// - `jwk_url` (&[`str`]): The EVE Online JWK endpoint URL.
     ///
     /// # Returns
-    /// - [`EsiConfigBuilder`]: Instance with updated EVE Online JWK URL configuration.
+    /// - [`ConfigBuilder`]: Instance with updated EVE Online JWK URL configuration.
     pub fn jwk_url(mut self, jwk_url: &str) -> Self {
         self.jwt_key_cache_config.jwk_url = jwk_url.to_string();
         self
@@ -273,7 +273,7 @@ impl EsiConfigBuilder {
     /// - `duration` ([`Duration`]): The lifetime of the JWT keys stored in the cache.
     ///
     /// # Returns
-    /// - [`EsiConfigBuilder`]: Instance with the updated JWT key cache TTL
+    /// - [`ConfigBuilder`]: Instance with the updated JWT key cache TTL
     pub fn jwk_cache_ttl(mut self, duration: Duration) -> Self {
         self.jwt_key_cache_config.cache_ttl = duration;
         self
@@ -297,7 +297,7 @@ impl EsiConfigBuilder {
     /// - `duration` ([`Duration`]): The exponential backoff duration between each attempt.
     ///
     /// # Returns
-    /// - [`EsiConfigBuilder`]: Instance with the updated exponential backoff
+    /// - [`ConfigBuilder`]: Instance with the updated exponential backoff
     pub fn jwk_refresh_backoff(mut self, duration: Duration) -> Self {
         self.jwt_key_cache_config.refresh_backoff = duration;
         self
@@ -315,7 +315,7 @@ impl EsiConfigBuilder {
     ///   JWT key refresh.
     ///
     /// # Returns
-    /// - [`EsiConfigBuilder`]: Instance with the modified timeout setting.
+    /// - [`ConfigBuilder`]: Instance with the modified timeout setting.
     pub fn jwk_refresh_timeout(mut self, duration: Duration) -> Self {
         self.jwt_key_cache_config.refresh_timeout = duration;
         self
@@ -330,7 +330,7 @@ impl EsiConfigBuilder {
     /// - `duration` ([`Duration`]): Cooldown duration between background JWT key cache refresh attempts.
     ///
     /// # Returns
-    /// - [`EsiConfigBuilder`]: Instance with the modified background refresh cooldown.
+    /// - [`ConfigBuilder`]: Instance with the modified background refresh cooldown.
     pub fn jwk_refresh_cooldown(mut self, duration: Duration) -> Self {
         self.jwt_key_cache_config.refresh_cooldown = duration;
         self
@@ -353,7 +353,7 @@ impl EsiConfigBuilder {
     /// - `retry_attempts` ([`u32`]): The amount of retry attempts if a JWT key fetch fails.
     ///
     /// # Returns
-    /// - [`EsiConfigBuilder`]: Instance with the updated JWK refresh max retries
+    /// - [`ConfigBuilder`]: Instance with the updated JWK refresh max retries
     pub fn jwk_refresh_max_retries(mut self, retry_attempts: u32) -> Self {
         self.jwt_key_cache_config.refresh_max_retries = retry_attempts;
         self
@@ -379,7 +379,7 @@ impl EsiConfigBuilder {
     ///   is enabled.
     ///
     /// # Returns
-    /// - [`EsiConfigBuilder`]: Instance with the background refresh is enabled or disabled.
+    /// - [`ConfigBuilder`]: Instance with the background refresh is enabled or disabled.
     pub fn jwk_background_refresh_enabled(mut self, background_refresh_enabled: bool) -> Self {
         self.jwt_key_cache_config.background_refresh_enabled = background_refresh_enabled;
         self
@@ -398,7 +398,7 @@ impl EsiConfigBuilder {
     /// - `threshold_percent` ([`u64`]): A number representing the percentage of when the refresh should be triggered.
     ///
     /// # Returns
-    /// - [`EsiConfigBuilder`]: Instance with the modified proactive background refresh threshold percentage.
+    /// - [`ConfigBuilder`]: Instance with the modified proactive background refresh threshold percentage.
     pub fn jwk_background_refresh_threshold(mut self, threshold_percentage: u64) -> Self {
         self.jwt_key_cache_config.background_refresh_threshold = threshold_percentage;
         self
@@ -409,11 +409,11 @@ impl EsiConfigBuilder {
 mod tests {
     use super::*;
 
-    /// Ensures that all setter methods for [`EsiConfigBuilder`] work as expected
+    /// Ensures that all setter methods for [`ConfigBuilder`] work as expected
     ///
     /// Test Setup
-    /// - Create a new instance of [`EsiConfigBuilder`] and use each setter method
-    /// - Build the [`EsiConfigBuilder`] returning an [`EsiConfig`]
+    /// - Create a new instance of [`ConfigBuilder`] and use each setter method
+    /// - Build the [`ConfigBuilder`] returning an [`Config`]
     ///
     /// Assertions
     /// - Assert URL settings were set as expected
@@ -423,7 +423,7 @@ mod tests {
     fn test_config_setter_methods() {
         let zero_seconds = Duration::from_secs(0);
 
-        let config = EsiConfig::builder()
+        let config = Config::builder()
             // URL settings
             .auth_url("https://example.com")
             .token_url("https://example.com")
@@ -438,7 +438,7 @@ mod tests {
             .jwk_background_refresh_enabled(false)
             .jwk_background_refresh_threshold(1)
             .build()
-            .expect("Failed to build EsiConfig");
+            .expect("Failed to build Config");
 
         // Assert URL settings were set
         let auth_url = AuthUrl::new("https://example.com".to_string()).unwrap();
@@ -466,15 +466,15 @@ mod tests {
     /// Expect an error setting the JWK background refresh threshold to 0
     ///
     /// # Test Setup
-    /// - Attempt to build a [`EsiConfig`] with the jwk_background_refresh_threshold to 0
+    /// - Attempt to build a [`Config`] with the jwk_background_refresh_threshold to 0
     ///
     /// # Assertions
     /// - Assert result is an error
     /// - Assert error is of type [`OAuthConfigError::InvalidBackgroundRefreshThreshold`]
     #[test]
     fn test_invalid_background_refresh_threshold_0() {
-        // Create a EsiConfig with invalid threshold percent
-        let result = EsiConfig::builder()
+        // Create a Config with invalid threshold percent
+        let result = Config::builder()
             .jwk_background_refresh_threshold(0)
             .build();
 
@@ -493,22 +493,22 @@ mod tests {
     /// Expect an error setting the JWK background refresh threshold to 100
     ///
     /// # Test Setup
-    /// - Attempt to build an [`EsiConfig`] with the jwk_background_refresh_threshold to 100
+    /// - Attempt to build an [`Config`] with the jwk_background_refresh_threshold to 100
     ///
     /// # Assertions
     /// - Assert result is an error
-    /// - Assert error is of type [`EsiConfigError::InvalidBackgroundRefreshThreshold`]
+    /// - Assert error is of type [`ConfigError::InvalidBackgroundRefreshThreshold`]
     #[test]
     fn test_invalid_background_refresh_threshold_100() {
-        // Create a EsiConfig with invalid threshold percent
-        let result = EsiConfig::builder()
+        // Create a Config with invalid threshold percent
+        let result = Config::builder()
             .jwk_background_refresh_threshold(100)
             .build();
 
         // Assert result is error
         assert!(result.is_err());
 
-        // Assert error is of type EsiConfigError::InvalidBackgroundRefreshThreshold
+        // Assert error is of type ConfigError::InvalidBackgroundRefreshThreshold
         assert!(matches!(
             result,
             Err(Error::ConfigError(
@@ -517,45 +517,45 @@ mod tests {
         ))
     }
 
-    /// Tests the attempting initialize an EsiConfig with an invalid auth_url
+    /// Tests the attempting initialize an Config with an invalid auth_url
     ///
     /// # Test Setup
-    /// - Attempt to build an EsiConfig with the auth_url set to an invalid URL.
+    /// - Attempt to build an Config with the auth_url set to an invalid URL.
     ///
     /// # Assertions
-    /// - Verifies that the error response is EsiConfigError::InvalidAuthUrl
+    /// - Verifies that the error response is ConfigError::InvalidAuthUrl
     #[test]
     fn test_invalid_auth_url() {
-        // Create an EsiConfig with an invalid auth_url
-        let result = EsiConfig::builder().auth_url("invalid_url").build();
+        // Create an Config with an invalid auth_url
+        let result = Config::builder().auth_url("invalid_url").build();
 
         // Assert result is an Error
         assert!(result.is_err());
 
         match result {
-            // Assert error is of the EsiConfigError:InvalidAuthUrl variant
+            // Assert error is of the ConfigError:InvalidAuthUrl variant
             Err(Error::ConfigError(ConfigError::InvalidAuthUrl)) => {}
             _ => panic!("Expected InvalidAuthUrl error"),
         }
     }
 
-    /// Tests the attempting initialize an EsiConfig with an invalid token_url
+    /// Tests the attempting initialize an Config with an invalid token_url
     ///
     /// # Test Setup
-    /// - Attempt to build an EsiConfig with the token_url set to an invalid URL.
+    /// - Attempt to build an Config with the token_url set to an invalid URL.
     ///
     /// # Assertions
-    /// - Verifies that the error response is EsiConfigError::InvalidTokenUrl
+    /// - Verifies that the error response is ConfigError::InvalidTokenUrl
     #[test]
     fn test_invalid_token_url() {
-        // Create an EsiConfig with an invalid token_url
-        let result = EsiConfig::builder().token_url("invalid_url").build();
+        // Create an Config with an invalid token_url
+        let result = Config::builder().token_url("invalid_url").build();
 
         // Assert result is an Error
         assert!(result.is_err());
 
         match result {
-            // Assert error is of the EsiConfigError:InvalidTokenUrl variant
+            // Assert error is of the ConfigError:InvalidTokenUrl variant
             Err(Error::ConfigError(ConfigError::InvalidTokenUrl)) => {}
             _ => panic!("Expected InvalidTokenUrl error"),
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 //! # EVE Online ESI Client Config
 //!
-//! Provides methods to override defaults for the [`EsiClient`]. This allows the
+//! Provides methods to override defaults for the [`Client`]. This allows the
 //! modification of the base ESI URL, OAuth2 endpoint URLs and the logic of how JWT
 //! key caching and refreshing is handled.
 //!
@@ -35,7 +35,6 @@
 //! ```
 //! use std::time::Duration;
 //!
-//! use eve_esi::EsiClient;
 //! use eve_esi::config::EsiConfig;
 //!
 //! // Build a config to override defaults
@@ -45,12 +44,12 @@
 //!     .build()
 //!     .expect("Failed to build EsiConfig");
 //!
-//! // Apply config settings to EsiClient
-//! let esi_client = EsiClient::builder()
+//! // Apply config settings to Client
+//! let esi_client = eve_esi::Client::builder()
 //!     .config(config)
 //!     .user_agent("MyApp/1.0 (contact@example.com")
 //!     .build()
-//!     .expect("Failed to build EsiClient");
+//!     .expect("Failed to build Client");
 //! ```
 
 use std::time::Duration;
@@ -63,7 +62,7 @@ use crate::{
     oauth2::jwk::cache::JwtKeyCacheConfig,
 };
 
-/// Configuration settings for the [`EsiClient`](crate::EsiClient)
+/// Configuration settings for the [`Client`](crate::Client)
 ///
 /// For a full overview, features, and usage examples, see the [module-level documentation](self).
 pub struct EsiConfig {
@@ -80,7 +79,7 @@ pub struct EsiConfig {
     pub(crate) jwt_key_cache_config: JwtKeyCacheConfig,
 }
 
-/// Builder struct for configuring & constructing an [`EsiConfig`] to override default [`EsiClient`](crate::EsiClient) settings
+/// Builder struct for configuring & constructing an [`EsiConfig`] to override default [`Client`](crate::Client) settings
 ///
 /// For a full overview, features, and usage examples, see the [module-level documentation](self).
 pub struct EsiConfigBuilder {

--- a/src/endpoints/alliance.rs
+++ b/src/endpoints/alliance.rs
@@ -28,7 +28,7 @@
 //! }
 //! ```
 
-use crate::{error::EsiError, model::alliance::Alliance, EsiClient};
+use crate::{error::Error, model::alliance::Alliance, EsiClient};
 
 /// Provides methods for accessing character-related endpoints of the EVE Online ESI API.
 ///
@@ -82,7 +82,7 @@ impl<'a> AllianceApi<'a> {
     ///     println!("Alliance name: {}", alliance.name);
     /// }
     /// ```
-    pub async fn get_alliance_information(&self, alliance_id: i32) -> Result<Alliance, EsiError> {
+    pub async fn get_alliance_information(&self, alliance_id: i32) -> Result<Alliance, Error> {
         let url = format!("{}/alliances/{}/", self.client.esi_url, alliance_id);
 
         Ok(self.client.get_from_public_esi::<Alliance>(&url).await?)

--- a/src/endpoints/alliance.rs
+++ b/src/endpoints/alliance.rs
@@ -4,7 +4,7 @@
 //! alliance-related endpoints of the EVE Online ESI (EVE Swagger Interface) API.
 //!
 //! The [`AllianceApi`] acts as a high-level interface for retrieving public information
-//! and affiliations for EVE Online alliances. It requires an [`EsiClient`] instance
+//! and affiliations for EVE Online alliances. It requires an [`Client`] instance
 //! to perform HTTP requests to the ESI endpoints.
 //!
 //! # Features
@@ -17,10 +17,10 @@
 //! ```no_run
 //! #[tokio::main]
 //! async fn main() {
-//!     let esi_client = eve_esi::EsiClient::builder()
+//!     let esi_client = eve_esi::Client::builder()
 //!         .user_agent("MyApp/1.0 (contact@example.com)")
 //!         .build()
-//!         .expect("Failed to build EsiClient");
+//!         .expect("Failed to build Client");
 //!
 //!     // Get information about The Autumn alliance (id: 99013534)
 //!     let alliance = esi_client.alliance().get_alliance_information(99013534).await.unwrap();
@@ -28,27 +28,27 @@
 //! }
 //! ```
 
-use crate::{error::Error, model::alliance::Alliance, EsiClient};
+use crate::{model::alliance::Alliance, Client, Error};
 
 /// Provides methods for accessing character-related endpoints of the EVE Online ESI API.
 ///
 /// The `AllianceApi` struct acts as an interface for retrieving information about EVE Online alliances
-/// using the ESI API. It requires an [`EsiClient`] for making HTTP requests to the ESI endpoints.
+/// using the ESI API. It requires an [`Client`] for making HTTP requests to the ESI endpoints.
 ///
 /// See the [module-level documentation](self) for an overview and usage example.
 pub struct AllianceApi<'a> {
-    client: &'a EsiClient,
+    client: &'a Client,
 }
 
 impl<'a> AllianceApi<'a> {
     /// Creates a new instance of `AllianceApi`.
     ///
     /// # Arguments
-    /// - `client` - The [`EsiClient`] used for making HTTP requests to the ESI endpoints.
+    /// - `client` - The [`Client`] used for making HTTP requests to the ESI endpoints.
     ///
     /// # Returns
     /// Returns a new instance of `AllianceApi`.
-    pub fn new(client: &'a EsiClient) -> Self {
+    pub fn new(client: &'a Client) -> Self {
         Self { client }
     }
 
@@ -72,10 +72,10 @@ impl<'a> AllianceApi<'a> {
     /// ```no_run
     /// #[tokio::main]
     /// async fn main() {
-    ///     let esi_client = eve_esi::EsiClient::builder()
+    ///     let esi_client = eve_esi::Client::builder()
     ///         .user_agent("MyApp/1.0 (contact@example.com)")
     ///         .build()
-    ///         .expect("Failed to build EsiClient");
+    ///         .expect("Failed to build Client");
     ///
     ///     // Get information about The Autumn alliance (id: 99013534)
     ///     let alliance = esi_client.alliance().get_alliance_information(99013534).await.unwrap();

--- a/src/endpoints/character.rs
+++ b/src/endpoints/character.rs
@@ -28,7 +28,7 @@
 //!     println!("Character name: {}", character.name);
 //! }
 //! ```
-use crate::error::EsiError;
+use crate::error::Error;
 use crate::EsiClient;
 
 use crate::model::character::{Character, CharacterAffiliation};
@@ -89,7 +89,7 @@ impl<'a> CharacterApi<'a> {
     pub async fn get_character_public_information(
         &self,
         character_id: i32,
-    ) -> Result<Character, EsiError> {
+    ) -> Result<Character, Error> {
         let url = format!("{}/characters/{}/", self.client.esi_url, character_id);
 
         Ok(self.client.get_from_public_esi::<Character>(&url).await?)
@@ -135,7 +135,7 @@ impl<'a> CharacterApi<'a> {
     pub async fn character_affiliation(
         &self,
         character_ids: Vec<i32>,
-    ) -> Result<Vec<CharacterAffiliation>, EsiError> {
+    ) -> Result<Vec<CharacterAffiliation>, Error> {
         let url = format!("{}/characters/affiliation/", self.client.esi_url);
         let esi_client = self.client;
 

--- a/src/endpoints/character.rs
+++ b/src/endpoints/character.rs
@@ -4,7 +4,7 @@
 //! character-related endpoints of the EVE Online ESI (EVE Swagger Interface) API.
 //!
 //! The [`CharacterApi`] acts as a high-level interface for retrieving public information
-//! and affiliations for EVE Online characters. It requires an [`EsiClient`] instance
+//! and affiliations for EVE Online characters. It requires an [`Client`] instance
 //! to perform HTTP requests to the ESI endpoints.
 //!
 //! # Features
@@ -18,10 +18,10 @@
 //! ```no_run
 //! #[tokio::main]
 //! async fn main() {
-//!     let esi_client = eve_esi::EsiClient::builder()
+//!     let esi_client = eve_esi::Client::builder()
 //!         .user_agent("MyApp/1.0 (contact@example.com)")
 //!         .build()
-//!         .expect("Failed to build EsiClient");
+//!         .expect("Failed to build Client");
 //!
 //!     // Get public information for a character
 //!     let character = esi_client.character().get_character_public_information(2114794365).await.unwrap();
@@ -29,29 +29,29 @@
 //! }
 //! ```
 use crate::error::Error;
-use crate::EsiClient;
+use crate::Client;
 
 use crate::model::character::{Character, CharacterAffiliation};
 
 /// Provides methods for accessing character-related endpoints of the EVE Online ESI API.
 ///
 /// The `CharacterApi` struct acts as an interface for retrieving information about EVE Online characters
-/// using the ESI API. It requires an [`EsiClient`] for making HTTP requests to the ESI endpoints.
+/// using the ESI API. It requires an [`Client`] for making HTTP requests to the ESI endpoints.
 ///
 /// See the [module-level documentation](self) for an overview and usage example.
 pub struct CharacterApi<'a> {
-    client: &'a EsiClient,
+    client: &'a Client,
 }
 
 impl<'a> CharacterApi<'a> {
     /// Creates a new instance of `CharacterApi`.
     ///
     /// # Arguments
-    /// - `client` - The [`EsiClient`] used for making HTTP requests to the ESI endpoints.
+    /// - `client` - The [`Client`] used for making HTTP requests to the ESI endpoints.
     ///
     /// # Returns
     /// Returns a new instance of `CharacterApi`.
-    pub fn new(client: &'a EsiClient) -> Self {
+    pub fn new(client: &'a Client) -> Self {
         Self { client }
     }
 
@@ -76,10 +76,10 @@ impl<'a> CharacterApi<'a> {
     /// ```no_run
     /// #[tokio::main]
     /// async fn main() {
-    ///     let esi_client = eve_esi::EsiClient::builder()
+    ///     let esi_client = eve_esi::Client::builder()
     ///         .user_agent("MyApp/1.0 (contact@example.com)")
     ///         .build()
-    ///         .expect("Failed to build EsiClient");
+    ///         .expect("Failed to build Client");
     ///
     ///     // Get information about the character Hyziri (id: 2114794365)
     ///     let character = esi_client.character().get_character_public_information(2114794365).await.unwrap();
@@ -115,10 +115,10 @@ impl<'a> CharacterApi<'a> {
     /// ```no_run
     /// #[tokio::main]
     /// async fn main() {
-    ///     let esi_client = eve_esi::EsiClient::builder()
+    ///     let esi_client = eve_esi::Client::builder()
     ///         .user_agent("MyApp/1.0 (contact@example.com)")
     ///         .build()
-    ///         .expect("Failed to build EsiClient");
+    ///         .expect("Failed to build Client");
     ///
     ///     // Get affiliations for characters with IDs 2114794365 and 2117053828
     ///     let affiliations = esi_client.character().character_affiliation(vec![2114794365, 2117053828]).await.unwrap();

--- a/src/endpoints/corporation.rs
+++ b/src/endpoints/corporation.rs
@@ -28,7 +28,7 @@
 //! }
 //! ```
 
-use crate::error::EsiError;
+use crate::error::Error;
 use crate::model::corporation::Corporation;
 use crate::EsiClient;
 
@@ -87,7 +87,7 @@ impl<'a> CorporationApi<'a> {
     pub async fn get_corporation_information(
         &self,
         corporation_id: i32,
-    ) -> Result<Corporation, EsiError> {
+    ) -> Result<Corporation, Error> {
         let url = format!("{}/corporations/{}/", self.client.esi_url, corporation_id);
 
         Ok(self.client.get_from_public_esi::<Corporation>(&url).await?)

--- a/src/endpoints/corporation.rs
+++ b/src/endpoints/corporation.rs
@@ -4,7 +4,7 @@
 //! corporation-related endpoints of the EVE Online ESI (EVE Swagger Interface) API.
 //!
 //! The [`CorporationApi`] acts as a high-level interface for retrieving public information
-//! and affiliations for EVE Online corporations. It requires an [`EsiClient`] instance
+//! and affiliations for EVE Online corporations. It requires an [`Client`] instance
 //! to perform HTTP requests to the ESI endpoints.
 //!
 //! # Features
@@ -17,10 +17,10 @@
 //! ```no_run
 //! #[tokio::main]
 //! async fn main() {
-//!     let esi_client = eve_esi::EsiClient::builder()
+//!     let esi_client = eve_esi::Client::builder()
 //!         .user_agent("MyApp/1.0 (contact@example.com)")
 //!         .build()
-//!         .expect("Failed to build EsiClient");
+//!         .expect("Failed to build Client");
 //!
 //!     // Get information about the corporation The Order of Autumn (id: 98785281)
 //!     let corporation = esi_client.corporation().get_corporation_information(98785281).await.unwrap();
@@ -30,27 +30,27 @@
 
 use crate::error::Error;
 use crate::model::corporation::Corporation;
-use crate::EsiClient;
+use crate::Client;
 
 /// Provides methods for accessing corporation-related endpoints of the EVE Online ESI API.
 ///
 /// The `CorporationApi` struct acts as an interface for retrieving information about EVE Online corporations
-/// using the ESI API. It requires an [`EsiClient`] for making HTTP requests to the ESI endpoints.
+/// using the ESI API. It requires an [`Client`] for making HTTP requests to the ESI endpoints.
 ///
 /// See the [module-level documentation](self) for an overview and usage example.
 pub struct CorporationApi<'a> {
-    client: &'a EsiClient,
+    client: &'a Client,
 }
 
 impl<'a> CorporationApi<'a> {
     /// Creates a new instance of `CorporationApi`.
     ///
     /// # Arguments
-    /// - `client` - The [`EsiClient`] used for making HTTP requests to the ESI endpoints.
+    /// - `client` - The [`Client`] used for making HTTP requests to the ESI endpoints.
     ///
     /// # Returns
     /// Returns a new instance of `CorporationApi`.
-    pub fn new(client: &'a EsiClient) -> Self {
+    pub fn new(client: &'a Client) -> Self {
         Self { client }
     }
 
@@ -74,10 +74,10 @@ impl<'a> CorporationApi<'a> {
     /// ```no_run
     /// #[tokio::main]
     /// async fn main() {
-    ///     let esi_client = eve_esi::EsiClient::builder()
+    ///     let esi_client = eve_esi::Client::builder()
     ///         .user_agent("MyApp/1.0 (contact@example.com)")
     ///         .build()
-    ///         .expect("Failed to build EsiClient");
+    ///         .expect("Failed to build Client");
     ///
     ///     // Get information about the corporation The Order of Autumn (id: 98785281)
     ///     let corporation = esi_client.corporation().get_corporation_information(98785281).await.unwrap();

--- a/src/endpoints/endpoints.rs
+++ b/src/endpoints/endpoints.rs
@@ -1,10 +1,10 @@
-//! Implements ESI endpoints for usage with the [`EsiClient`]
+//! Implements ESI endpoints for usage with the [`Client`]
 //!
 //! For details on usage see [module-level documentation](super)
 
-use crate::EsiClient;
+use crate::Client;
 
-impl EsiClient {
+impl Client {
     /// Access to Alliance ESI endpoints
     ///
     /// Returns an API client for interacting with alliance-related endpoints.

--- a/src/endpoints/mod.rs
+++ b/src/endpoints/mod.rs
@@ -15,10 +15,10 @@
 //! ```no_run
 //! #[tokio::main]
 //! async fn main() {
-//!     let esi_client = eve_esi::EsiClient::builder()
+//!     let esi_client = eve_esi::Client::builder()
 //!         .user_agent("MyApp/1.0 (contact@example.com)")
 //!         .build()
-//!         .expect("Failed to build EsiClient");
+//!         .expect("Failed to build Client");
 //!
 //!     // Get information about the corporation The Order of Autumn (id: 98785281)
 //!     let corporation = esi_client.corporation().get_corporation_information(98785281).await.unwrap();

--- a/src/error.rs
+++ b/src/error.rs
@@ -69,12 +69,12 @@ pub use crate::oauth2::error::OAuthError;
 /// error types for granular handling.
 ///
 #[derive(Error, Debug)]
-pub enum EsiError {
+pub enum Error {
     /// Config errors related to building a [`EsiConfig`](crate::EsiConfig) or [`EsiClient`](crate::EsiClient)
     ///
     /// For a more detailed description, see [`EsiConfigError`]
     #[error(transparent)]
-    EsiConfigError(EsiConfigError),
+    ConfigError(ConfigError),
     /// Runtime errors related to the EVE Online OAuth2 authentication process.
     ///
     /// For a more detailed description, see [`OAuthError`].
@@ -104,7 +104,7 @@ pub enum EsiError {
 /// You can match on [`EsiConfigError`] to handle errors at a high level, or downcast to more specific
 /// error types for granular handling.
 #[derive(Error, Debug)]
-pub enum EsiConfigError {
+pub enum ConfigError {
     /// Error returned when the ESI client ID is missing.
     ///
     /// This error occurs when attempting to access EVE Online's OAuth2

--- a/src/error.rs
+++ b/src/error.rs
@@ -18,17 +18,13 @@
 //! # Example
 //!
 //! ```rust
-//! use eve_esi::error::EsiError;
-//! use eve_esi::oauth2::ScopeBuilder;
-//! use eve_esi::EsiClient;
-//!
 //! // Don't set any OAuth2 related settings
-//! let esi_client = EsiClient::builder()
+//! let esi_client = eve_esi::Client::builder()
 //!     .user_agent("MyApp/1.0 (contact@example.com)")
 //!     .build()
-//!     .expect("Failed to build EsiClient");
+//!     .expect("Failed to build Client");
 //!
-//! let scopes = ScopeBuilder::new()
+//! let scopes = eve_esi::ScopeBuilder::new()
 //!     .public_data()
 //!     .build();
 //!
@@ -38,7 +34,7 @@
 //! // Handle error types
 //! match result {
 //!     Ok(_) => { /* ... */ }
-//!     Err(EsiError::OAuthError(oauth_err)) => {
+//!     Err(eve_esi::Error::OAuthError(oauth_err)) => {
 //!         // Handle OAuth2-specific error
 //!         println!("OAuth2 error: {oauth_err}");
 //!     }
@@ -59,10 +55,10 @@ pub use crate::oauth2::error::OAuthError;
 /// See the [module-level documentation](self) for an overview and usage example.
 ///
 /// # Variants
-/// - [`EsiConfigError`](EsiError::EsiConfigError) - Errors due to configuration issues when building an [`EsiClient`](crate::EsiClient)
+/// - [`ConfigError`](Error::ConfigError) - Errors due to configuration issues when building an [`Client`](crate::Client)
 ///   or [`EsiConfig`](crate::config::EsiConfig)
-/// - [`OAuthError`](EsiError::OAuthError) - Errors related to OAuth2 authentication. See [`OAuthError`] for details.
-/// - [`ReqwestError`](EsiError::ReqwestError) - Errors that occur during HTTP requests. See [`reqwest::Error`] for details.
+/// - [`OAuthError`](Error::OAuthError) - Errors related to OAuth2 authentication. See [`OAuthError`] for details.
+/// - [`ReqwestError`](Error::ReqwestError) - Errors that occur during HTTP requests. See [`reqwest::Error`] for details.
 ///
 /// # Usage
 /// You can match on [`EsiError`] to handle errors at a high level, or downcast to more specific
@@ -70,7 +66,7 @@ pub use crate::oauth2::error::OAuthError;
 ///
 #[derive(Error, Debug)]
 pub enum Error {
-    /// Config errors related to building a [`EsiConfig`](crate::EsiConfig) or [`EsiClient`](crate::EsiClient)
+    /// Config errors related to building a [`EsiConfig`](crate::EsiConfig) or [`Client`](crate::Client)
     ///
     /// For a more detailed description, see [`EsiConfigError`]
     #[error(transparent)]
@@ -87,7 +83,7 @@ pub enum Error {
     ReqwestError(#[from] reqwest::Error),
 }
 
-/// Errors when building a new [`EsiClient`](crate::EsiClient) or [`EsiConfig`](crate::config::EsiConfig)
+/// Errors when building a new [`Client`](crate::Client) or [`EsiConfig`](crate::config::EsiConfig)
 ///
 /// This enum represents the various errors which could occur due to an improper configuration such as an
 /// improper URL format or an invalid JWT key background refresh threshold.
@@ -108,7 +104,7 @@ pub enum ConfigError {
     /// Error returned when the ESI client ID is missing.
     ///
     /// This error occurs when attempting to access EVE Online's OAuth2
-    /// without first setting the client ID on the [`EsiClient`](crate::EsiClient).
+    /// without first setting the client ID on the [`Client`](crate::Client).
     ///
     /// # Resolution
     /// To fix this:
@@ -129,7 +125,7 @@ pub enum ConfigError {
     /// Error returned when the ESI client secret is missing.
     ///
     /// This error occurs when attempting to access EVE Online's OAuth2
-    /// without first setting the client secret on the [`EsiClient`](crate::EsiClient).
+    /// without first setting the client secret on the [`Client`](crate::Client).
     ///
     /// # Resolution
     /// To fix this:
@@ -150,7 +146,7 @@ pub enum ConfigError {
     /// Error returned when the ESI callback URL is missing.
     ///
     /// This error occurs when attempting to access EVE Online's OAuth2
-    /// without first setting the callback URL on the [`EsiClient`](crate::EsiClient).
+    /// without first setting the callback URL on the [`Client`](crate::Client).
     ///
     /// # Resolution
     /// To fix this:
@@ -183,7 +179,7 @@ pub enum ConfigError {
         "Invalid EVE OAuth2 callback URL:\n\
         \n\
         To fix this:\n\
-          - Use the default URL provided by the EsiClient\n\
+          - Use the default URL provided by the Client\n\
           - Validate the url set using `esi_client_builder.callback_url(callback_url)`\n\
             is using a url that is correctly formatted\n\
             e.g. https://example.com/callback\n\

--- a/src/esi.rs
+++ b/src/esi.rs
@@ -1,8 +1,8 @@
 use serde::{de::DeserializeOwned, Serialize};
 
-use crate::EsiClient;
+use crate::Client;
 
-impl EsiClient {
+impl Client {
     /// Makes an unauthenticated GET request to the ESI API.
     ///
     /// # Arguments

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,15 +11,15 @@
 //!
 //! # Usage
 //!
-//! Create a new EsiClient instance and request public information about a character from ESI.
+//! Create a new Client instance and request public information about a character from ESI.
 //!
 //! ```no_run
 //! #[tokio::main]
 //! async fn main() {
-//!     let esi_client = eve_esi::EsiClient::builder()
+//!     let esi_client = eve_esi::Client::builder()
 //!         .user_agent("MyApp/1.0 (contact@example.com)")
 //!         .build()
-//!         .expect("Failed to build EsiClient");
+//!         .expect("Failed to build Client");
 //!
 //!     // Get information about the corporation The Order of Autumn (id: 98785281)
 //!     let corporation = esi_client.corporation().get_corporation_information(98785281).await.unwrap();
@@ -53,10 +53,10 @@
 //! env_logger::init();
 //!
 //! // Now logs from eve_esi will be captured
-//! let esi_client = eve_esi::EsiClient::builder()
+//! let esi_client = eve_esi::Client::builder()
 //!     .user_agent("MyApp/1.0 (contact@example.com)")
 //!     .build()
-//!     .expect("Failed to build EsiClient");
+//!     .expect("Failed to build Client");
 //! ```
 
 pub mod builder;
@@ -67,11 +67,12 @@ pub mod error;
 pub mod model;
 pub mod oauth2;
 
-pub use crate::builder::EsiClientBuilder;
-pub use crate::client::EsiClient;
+pub use crate::builder::ClientBuilder;
+pub use crate::client::Client;
 pub use crate::config::{EsiConfig, EsiConfigBuilder};
 pub use crate::error::{ConfigError, Error};
 pub use crate::oauth2::error::OAuthError;
+pub use crate::oauth2::ScopeBuilder;
 
 mod constant;
 mod esi;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ pub mod oauth2;
 
 pub use crate::builder::ClientBuilder;
 pub use crate::client::Client;
-pub use crate::config::{EsiConfig, EsiConfigBuilder};
+pub use crate::config::{Config, ConfigBuilder};
 pub use crate::error::{ConfigError, Error};
 pub use crate::oauth2::error::OAuthError;
 pub use crate::oauth2::ScopeBuilder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,11 @@ pub mod error;
 pub mod model;
 pub mod oauth2;
 
+pub use crate::builder::EsiClientBuilder;
 pub use crate::client::EsiClient;
+pub use crate::config::{EsiConfig, EsiConfigBuilder};
+pub use crate::error::{ConfigError, Error};
+pub use crate::oauth2::error::OAuthError;
 
 mod constant;
 mod esi;

--- a/src/oauth2/client.rs
+++ b/src/oauth2/client.rs
@@ -1,15 +1,15 @@
 //! # EVE Online OAuth2 Client
 //!
-//! Allows the EsiClient to authenticate with the EVE Online API using OAuth2
+//! Allows the Client to authenticate with the EVE Online API using OAuth2
 //! using the provided client ID, client secret, and callback URL.
 //!
 //! This module uses the [`oauth2`](https://crates.io/crates/oauth2) crate to configure
-//! the OAuth2 client for the EsiClient.
+//! the OAuth2 client for the Client.
 //!
-//! This client is only used internally by the [`EsiClient`](crate::EsiClient).
+//! This client is only used internally by the [`Client`](crate::Client).
 //!
 //! - See [module-level documentation](super) for a higher level overview and usage example
-//! - See [EsiClientBuilder docs](crate::builder) for instructions on setting up OAuth2 for the eve_esi crate.
+//! - See [ClientBuilder docs](crate::builder) for instructions on setting up OAuth2 for the eve_esi crate.
 
 use oauth2::basic::{BasicClient, BasicErrorResponseType, BasicTokenType};
 use oauth2::{
@@ -18,16 +18,16 @@ use oauth2::{
     StandardTokenIntrospectionResponse, StandardTokenResponse,
 };
 
-use crate::builder::EsiClientBuilder;
+use crate::builder::ClientBuilder;
 use crate::config::EsiConfig;
 use crate::error::{ConfigError, Error};
 
-/// OAuth2 client type for [`EsiClient`](crate::EsiClient)
+/// OAuth2 client type for [`Client`](crate::Client)
 ///
 /// This type represents a client from the oauth2 library which is used
-/// within the [`EsiClient`](crate::EsiClient) to authenticate with the EVE Online API using OAuth2.
+/// within the [`Client`](crate::Client) to authenticate with the EVE Online API using OAuth2.
 ///
-/// This is intended only for internal use by the [`EsiClient`](crate::EsiClient).
+/// This is intended only for internal use by the [`Client`](crate::Client).
 pub(crate) type OAuth2Client = Client<
     StandardErrorResponse<BasicErrorResponseType>,
     StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType>,
@@ -41,15 +41,15 @@ pub(crate) type OAuth2Client = Client<
     EndpointSet,
 >;
 
-impl EsiClientBuilder {
-    /// Sets up the OAuth2 client for the [`EsiClient`](crate::EsiClient).
+impl ClientBuilder {
+    /// Sets up the OAuth2 client for the [`Client`](crate::Client).
     ///
     /// This method configures the OAuth2 client with the provided client ID, client secret, and callback URL.
     ///
-    /// This is intended only for internal use by the [`EsiClient`](crate::EsiClient).
+    /// This is intended only for internal use by the [`Client`](crate::Client).
     ///
     /// # Arguments
-    /// - `self` ([`EsiClientBuilder`]): Builder used to set the `client_id`, `client_secret`, and `callback_url`
+    /// - `self` ([`ClientBuilder`]): Builder used to set the `client_id`, `client_secret`, and `callback_url`
     /// - `config` (&[`EsiConfig`]): Config used to set the EVE Online OAuth2 endpoint URLs
     ///
     /// # Returns
@@ -95,19 +95,19 @@ impl EsiClientBuilder {
 #[cfg(test)]
 mod tests {
     use crate::error::{ConfigError, Error};
-    use crate::EsiClient;
+    use crate::Client;
 
-    /// Tests the successful build of the OAuth2 client for the [`EsiClient`]
+    /// Tests the successful build of the OAuth2 client for the [`Client`]
     ///
     /// # Test Setup
-    /// - Build an EsiClient with all OAuth2 client related setter methods set
+    /// - Build an Client with all OAuth2 client related setter methods set
     ///
     /// # Assertions
     /// - Assert result is Ok
     #[test]
     fn test_success() {
-        // Create an EsiClient config with all oauth client related setter methods
-        let result = EsiClient::builder()
+        // Create an Client config with all oauth client related setter methods
+        let result = Client::builder()
             .client_id("client_id")
             .client_secret("client_secret")
             .callback_url("http://localhost:8080/callback")
@@ -117,7 +117,7 @@ mod tests {
         assert!(result.is_ok())
     }
 
-    /// Tests the attempting to initialize an EsiClient for oauth2 with a missing client ID
+    /// Tests the attempting to initialize an Client for oauth2 with a missing client ID
     ///
     /// # Test Setup
     /// - Creates an ESI client with OAuth2 configured
@@ -126,7 +126,7 @@ mod tests {
     /// - Verifies that the error response is EsiConfigError::MissingClientId
     #[test]
     fn test_missing_client_id() {
-        let result = EsiClient::builder()
+        let result = Client::builder()
             .user_agent("MyApp/1.0 (contact@example.com)")
             .client_secret("client_secret")
             .callback_url("http://localhost:8080/callback")
@@ -143,7 +143,7 @@ mod tests {
         }
     }
 
-    /// Tests the attempting to initialize an EsiClient for oauth2 with a missing client secret
+    /// Tests the attempting to initialize an Client for oauth2 with a missing client secret
     ///
     /// # Test Setup
     /// - Creates an ESI client with the client_secret not set.
@@ -152,7 +152,7 @@ mod tests {
     /// - Verifies that the error response is EsiConfigError::MissingClientSecret
     #[test]
     fn test_missing_client_secret() {
-        let result = EsiClient::builder()
+        let result = Client::builder()
             .user_agent("MyApp/1.0 (contact@example.com)")
             .client_id("client_id")
             .callback_url("http://localhost:8080/callback")
@@ -169,7 +169,7 @@ mod tests {
         }
     }
 
-    /// Tests the attempting initialize an EsiClient for oauth2 with a missing callback_url
+    /// Tests the attempting initialize an Client for oauth2 with a missing callback_url
     ///
     /// # Test Setup
     /// - Creates an ESI client with the callback_url not set.
@@ -179,7 +179,7 @@ mod tests {
     #[test]
     fn test_missing_callback_url() {
         // Create an ESI client
-        let result = EsiClient::builder()
+        let result = Client::builder()
             .user_agent("MyApp/1.0 (contact@example.com)")
             .client_id("client_id")
             .client_secret("client_secret")
@@ -196,7 +196,7 @@ mod tests {
         }
     }
 
-    /// Tests the attempting initialize an EsiClient for oauth2 with an invalid callback_url
+    /// Tests the attempting initialize an Client for oauth2 with an invalid callback_url
     ///
     /// # Test Setup
     /// - Creates an ESI client with the callback_url set to an invalid URL.
@@ -205,7 +205,7 @@ mod tests {
     /// - Verifies that the error response is EsiConfigError::InvalidCallbackUrl
     #[test]
     fn test_invalid_callback_url() {
-        let result = EsiClient::builder()
+        let result = Client::builder()
             .user_agent("MyApp/1.0 (contact@example.com)")
             .client_id("client_id")
             .client_secret("client_secret")

--- a/src/oauth2/client.rs
+++ b/src/oauth2/client.rs
@@ -20,7 +20,7 @@ use oauth2::{
 
 use crate::builder::EsiClientBuilder;
 use crate::config::EsiConfig;
-use crate::error::{EsiConfigError, EsiError};
+use crate::error::{ConfigError, Error};
 
 /// OAuth2 client type for [`EsiClient`](crate::EsiClient)
 ///
@@ -60,29 +60,25 @@ impl EsiClientBuilder {
     ///   the callback URL is incorrectly formatted.
     /// - [`OAuthConfigError`]: Error if the auth URL or token URL has been changed from default and
     ///   is incorrectly formatted.
-    pub(crate) fn setup_oauth_client(self, config: &EsiConfig) -> Result<OAuth2Client, EsiError> {
+    pub(crate) fn setup_oauth_client(self, config: &EsiConfig) -> Result<OAuth2Client, Error> {
         // Get client_id & client_secret
         let client_id = match self.client_id.clone() {
             Some(id) => id.clone(),
-            None => return Err(EsiError::EsiConfigError(EsiConfigError::MissingClientId)),
+            None => return Err(Error::ConfigError(ConfigError::MissingClientId)),
         };
         let client_secret = match self.client_secret.clone() {
             Some(secret) => secret.clone(),
-            None => {
-                return Err(EsiError::EsiConfigError(
-                    EsiConfigError::MissingClientSecret,
-                ))
-            }
+            None => return Err(Error::ConfigError(ConfigError::MissingClientSecret)),
         };
 
         // Parse URLs
         let callback_url = match self.callback_url.clone() {
             Some(url) => url.clone(),
-            None => return Err(EsiError::EsiConfigError(EsiConfigError::MissingCallbackUrl)),
+            None => return Err(Error::ConfigError(ConfigError::MissingCallbackUrl)),
         };
         let redirect_url = match RedirectUrl::new(callback_url) {
             Ok(url) => url,
-            Err(_) => return Err(EsiError::EsiConfigError(EsiConfigError::InvalidCallbackUrl)),
+            Err(_) => return Err(Error::ConfigError(ConfigError::InvalidCallbackUrl)),
         };
 
         // Create OAuth2 Client
@@ -98,7 +94,7 @@ impl EsiClientBuilder {
 
 #[cfg(test)]
 mod tests {
-    use crate::error::{EsiConfigError, EsiError};
+    use crate::error::{ConfigError, Error};
     use crate::EsiClient;
 
     /// Tests the successful build of the OAuth2 client for the [`EsiClient`]
@@ -140,7 +136,7 @@ mod tests {
             Ok(_) => {
                 panic!("Expected Err");
             }
-            Err(EsiError::EsiConfigError(EsiConfigError::MissingClientId)) => {
+            Err(Error::ConfigError(ConfigError::MissingClientId)) => {
                 assert!(true);
             }
             Err(_) => panic!("Expected EsiError::MissingClientId"),
@@ -166,7 +162,7 @@ mod tests {
             Ok(_) => {
                 panic!("Expected Err");
             }
-            Err(EsiError::EsiConfigError(EsiConfigError::MissingClientSecret)) => {
+            Err(Error::ConfigError(ConfigError::MissingClientSecret)) => {
                 assert!(true);
             }
             Err(_) => panic!("Expected EsiError::MissingClientSecret"),
@@ -193,7 +189,7 @@ mod tests {
             Ok(_) => {
                 panic!("Expected Err");
             }
-            Err(EsiError::EsiConfigError(EsiConfigError::MissingCallbackUrl)) => {
+            Err(Error::ConfigError(ConfigError::MissingCallbackUrl)) => {
                 assert!(true);
             }
             Err(_) => panic!("Expected EsiError::MissingCallbackUrl"),
@@ -218,7 +214,7 @@ mod tests {
 
         assert!(result.is_err());
         match result {
-            Err(EsiError::EsiConfigError(EsiConfigError::InvalidCallbackUrl)) => {}
+            Err(Error::ConfigError(ConfigError::InvalidCallbackUrl)) => {}
             _ => panic!("Expected InvalidCallbackUrl error"),
         }
     }

--- a/src/oauth2/client.rs
+++ b/src/oauth2/client.rs
@@ -19,7 +19,7 @@ use oauth2::{
 };
 
 use crate::builder::ClientBuilder;
-use crate::config::EsiConfig;
+use crate::config::Config;
 use crate::error::{ConfigError, Error};
 
 /// OAuth2 client type for [`Client`](crate::Client)
@@ -50,17 +50,17 @@ impl ClientBuilder {
     ///
     /// # Arguments
     /// - `self` ([`ClientBuilder`]): Builder used to set the `client_id`, `client_secret`, and `callback_url`
-    /// - `config` (&[`EsiConfig`]): Config used to set the EVE Online OAuth2 endpoint URLs
+    /// - `config` (&[`Config`]): Config used to set the EVE Online OAuth2 endpoint URLs
     ///
     /// # Returns
-    /// - [`OAuth2Client`]: Instance with configured settings from [`EsiConfig`]
+    /// - [`OAuth2Client`]: Instance with configured settings from [`Config`]
     ///
     /// # Errors
     /// - [`OAuthError`]: Error if either the client ID, client secret, or callback URL is missing or
     ///   the callback URL is incorrectly formatted.
     /// - [`OAuthConfigError`]: Error if the auth URL or token URL has been changed from default and
     ///   is incorrectly formatted.
-    pub(crate) fn setup_oauth_client(self, config: &EsiConfig) -> Result<OAuth2Client, Error> {
+    pub(crate) fn setup_oauth_client(self, config: &Config) -> Result<OAuth2Client, Error> {
         // Get client_id & client_secret
         let client_id = match self.client_id.clone() {
             Some(id) => id.clone(),
@@ -123,7 +123,7 @@ mod tests {
     /// - Creates an ESI client with OAuth2 configured
     ///
     /// # Assertions
-    /// - Verifies that the error response is EsiConfigError::MissingClientId
+    /// - Verifies that the error response is ConfigError::MissingClientId
     #[test]
     fn test_missing_client_id() {
         let result = Client::builder()
@@ -149,7 +149,7 @@ mod tests {
     /// - Creates an ESI client with the client_secret not set.
     ///
     /// # Assertions
-    /// - Verifies that the error response is EsiConfigError::MissingClientSecret
+    /// - Verifies that the error response is ConfigError::MissingClientSecret
     #[test]
     fn test_missing_client_secret() {
         let result = Client::builder()
@@ -175,7 +175,7 @@ mod tests {
     /// - Creates an ESI client with the callback_url not set.
     ///
     /// # Assertions
-    /// - Verifies that the error response is EsiConfigError::MissingCallbackUrl
+    /// - Verifies that the error response is ConfigError::MissingCallbackUrl
     #[test]
     fn test_missing_callback_url() {
         // Create an ESI client
@@ -202,7 +202,7 @@ mod tests {
     /// - Creates an ESI client with the callback_url set to an invalid URL.
     ///
     /// # Assertions
-    /// - Verifies that the error response is EsiConfigError::InvalidCallbackUrl
+    /// - Verifies that the error response is ConfigError::InvalidCallbackUrl
     #[test]
     fn test_invalid_callback_url() {
         let result = Client::builder()

--- a/src/oauth2/error.rs
+++ b/src/oauth2/error.rs
@@ -9,24 +9,21 @@
 //!
 //! # Example
 //! ```
-//! use eve_esi::error::{EsiError, OAuthError};
-//! use eve_esi::oauth2::ScopeBuilder;
-//!
-//! let esi_client = eve_esi::EsiClient::builder()
+//! let esi_client = eve_esi::Client::builder()
 //!     .user_agent("MyApp/1.0 (contact@example.com)")
 //!     // Don't set .client_id()
 //!     // Don't set .client_secret()
 //!     // Don't set .callback_url()
 //!     .build()
-//!     .expect("Failed to build EsiClient");
+//!     .expect("Failed to build Client");
 //!
 //! // Using OAuth2 without configuring required settings causes a runtime error.
-//! let scopes = ScopeBuilder::new()
+//! let scopes = eve_esi::ScopeBuilder::new()
 //!     .public_data()
 //!     .build();
 //! let result = esi_client.oauth2().login_url(scopes);
 //!
-//! assert!(matches!(result, Err(EsiError::OAuthError(OAuthError::OAuth2NotConfigured))));
+//! assert!(matches!(result, Err(eve_esi::Error::OAuthError(eve_esi::OAuthError::OAuth2NotConfigured))));
 //! ```
 
 use oauth2::basic::BasicErrorResponseType;
@@ -42,7 +39,7 @@ use thiserror::Error;
 /// See the [module-level documentation](self) for an overview and usage example.
 ///
 /// # Variants
-/// - [`OAuth2NotConfigured`](OAuthError::OAuth2NotConfigured): Error returned when OAuth2 has not been configured for [`EsiClient`](crate::EsiClient).
+/// - [`OAuth2NotConfigured`](OAuthError::OAuth2NotConfigured): Error returned when OAuth2 has not been configured for [`Client`](crate::Client).
 /// - [`JwtKeyRefreshTimeout`](OAuthError::JwtKeyRefreshTimeout): Error when waiting for another thread to refresh JWT key cache times out
 /// - [`JwtKeyRefreshFailure`](OAuthError::JwtKeyRefreshFailure): Error when waiting for another thread to refresh JWT key cache fails
 /// - [`JwtKeyRefreshCooldown`](OAuthError::JwtKeyRefreshCooldown): Error when JWT key refresh is still in cooldown
@@ -54,32 +51,32 @@ use thiserror::Error;
 /// - Refreshing access tokens
 #[derive(Error, Debug)]
 pub enum OAuthError {
-    /// Error returned when OAuth2 has not been configured for [`EsiClient`](crate::EsiClient).
+    /// Error returned when OAuth2 has not been configured for [`Client`](crate::Client).
     ///
-    /// This error occurs when the [`EsiClient`](crate::EsiClient) is built without setting
+    /// This error occurs when the [`Client`](crate::Client) is built without setting
     /// the client ID, client secret, and callback URL. This error occurs at runtime rather
     /// than setup because it does not yet know if you'll be using OAuth2 features unless
     /// you set at least one of OAuth2 related settings or try to use an OAuth2 related method.
     ///
     /// # Resolution
-    /// To fix this configure your [`EsiClient`](crate::EsiClient) with the `client_id`, `client_secret`,
+    /// To fix this configure your [`Client`](crate::Client) with the `client_id`, `client_secret`,
     /// and `callback_url` from https://developers.eveonline.com/applications.
     ///
     /// ```
-    /// use eve_esi::EsiClient;
+    /// use eve_esi::Client;
     ///
-    /// let esi_client = EsiClient::builder()
+    /// let esi_client = Client::builder()
     ///     .user_agent("MyApp/1.0 (contact@example.com)")
     ///     .client_id("client_id")
     ///     .client_secret("client_secret")
     ///     .callback_url("http://localhost:8080/callback")
     ///     .build()
-    ///     .expect("Failed to build EsiClient");
+    ///     .expect("Failed to build Client");
     /// ```
     #[error(
-        "OAuth2 not configured for EsiClient\n\
+        "OAuth2 not configured for Client\n\
         \n\
-        To fix this configure your EsiClient with the client ID, client secret,\n\
+        To fix this configure your Client with the client ID, client secret,\n\
         and callback URL from https://developers.eveonline.com/applications\n\
         \n\
         See this example: https://github.com/hyziri/eve_esi/blob/main/examples/sso.rs"

--- a/src/oauth2/jwk/cache.rs
+++ b/src/oauth2/jwk/cache.rs
@@ -21,7 +21,7 @@ use log::{debug, trace};
 use tokio::sync::{Notify, RwLock};
 
 use crate::{
-    config::EsiConfig,
+    config::Config,
     constant::{
         DEFAULT_JWK_BACKGROUND_REFRESH_THRESHOLD_PERCENT, DEFAULT_JWK_CACHE_TTL,
         DEFAULT_JWK_REFRESH_BACKOFF, DEFAULT_JWK_REFRESH_COOLDOWN, DEFAULT_JWK_REFRESH_MAX_RETRIES,
@@ -120,7 +120,7 @@ impl JwtKeyCache {
     ///
     /// # Returns
     /// - [`JwtKeyCache`]: Default cache instance that contains no keys initially
-    pub(crate) fn new(config: &EsiConfig) -> Self {
+    pub(crate) fn new(config: &Config) -> Self {
         Self {
             cache: RwLock::new(None),
             refresh_lock: AtomicBool::new(false),

--- a/src/oauth2/jwk/cache.rs
+++ b/src/oauth2/jwk/cache.rs
@@ -319,7 +319,7 @@ impl JwtKeyCache {
 
 #[cfg(test)]
 mod cache_get_keys_tests {
-    use crate::{model::oauth2::EveJwtKeys, EsiClient};
+    use crate::{model::oauth2::EveJwtKeys, Client};
 
     /// Validates function returns Some keys when cache has keys
     ///
@@ -327,18 +327,18 @@ mod cache_get_keys_tests {
     /// function returns them properly without issues.
     ///
     /// # Test Setup
-    /// - Setup basic EsiClient
-    /// - Set EsiClient JWT key cache with mock keys
+    /// - Setup basic Client
+    /// - Set Client JWT key cache with mock keys
     ///
     /// # Assertions
     /// - Verify function returns Some(EveJwtKeys)
     #[tokio::test]
     async fn test_cache_get_keys_some() {
-        // Setup basic EsiClient
-        let esi_client = EsiClient::builder()
+        // Setup basic Client
+        let esi_client = Client::builder()
             .user_agent("MyApp/1.0 (contact@example.com)")
             .build()
-            .expect("Failed to build EsiClient");
+            .expect("Failed to build Client");
 
         let jwt_key_cache = esi_client.jwt_key_cache;
 
@@ -363,18 +363,18 @@ mod cache_get_keys_tests {
     /// function returns None as expected.
     ///
     /// # Test Setup
-    /// - Setup basic EsiClient
+    /// - Setup basic Client
     /// - Do not set the JWT key cache
     ///
     /// # Assertions
     /// - Verify function returns None
     #[tokio::test]
     async fn test_cache_get_keys_none() {
-        // Setup basic EsiClient
-        let esi_client = EsiClient::builder()
+        // Setup basic Client
+        let esi_client = Client::builder()
             .user_agent("MyApp/1.0 (contact@example.com)")
             .build()
-            .expect("Failed to build EsiClient");
+            .expect("Failed to build Client");
 
         let jwt_key_cache = esi_client.jwt_key_cache;
 
@@ -390,26 +390,26 @@ mod cache_get_keys_tests {
 
 #[cfg(test)]
 mod cache_update_keys_tests {
-    use crate::{model::oauth2::EveJwtKeys, EsiClient};
+    use crate::{model::oauth2::EveJwtKeys, Client};
 
     /// Validates that cache properly updates with new keys
     ///
     /// Checks that writing new keys to the JWT key cache on
-    /// EsiClient is successful.
+    /// Client is successful.
     ///
     /// # Test Setup
-    /// - Setup basic EsiClient
+    /// - Setup basic Client
     /// - Create mock JWT keys
     ///
     /// # Assertions
-    /// - Assert that the EsiClient jwt_keys_cache now is Some()
+    /// - Assert that the Client jwt_keys_cache now is Some()
     #[tokio::test]
     async fn test_cache_update_keys() {
-        // Setup basic EsiClient
-        let esi_client = EsiClient::builder()
+        // Setup basic Client
+        let esi_client = Client::builder()
             .user_agent("MyApp/1.0 (contact@example.com)")
             .build()
-            .expect("Failed to build EsiClient");
+            .expect("Failed to build Client");
 
         let jwt_key_cache = esi_client.jwt_key_cache;
 
@@ -429,27 +429,27 @@ mod cache_update_keys_tests {
 
 #[cfg(test)]
 mod jwk_refresh_lock_try_acquire_tests {
-    use crate::EsiClient;
+    use crate::Client;
 
     /// Checks that lock is properly acquired when not already in use
     ///
     /// Attempts to acquire a lock to refresh JWT keys on a new
-    /// EsiClient which should return as successful (true) indicating
+    /// Client which should return as successful (true) indicating
     /// that no other threads are currently attempting a key refresh.
     ///
     /// # Test Setup
-    /// - Setup a basic EsiClient
+    /// - Setup a basic Client
     /// - Attempt to acquire a lock for JWT key refresh
     ///
     /// # Assertions
     /// - Assert that result is true when acquiring lock
     #[test]
     fn test_jwk_refresh_lock_try_acquire_success() {
-        // Setup basic EsiClient
-        let esi_client = EsiClient::builder()
+        // Setup basic Client
+        let esi_client = Client::builder()
             .user_agent("MyApp/1.0 (contact@example.com)")
             .build()
-            .expect("Failed to build EsiClient");
+            .expect("Failed to build Client");
 
         // Attempt to acquire lock
         let jwt_key_cache = &esi_client.jwt_key_cache;
@@ -467,7 +467,7 @@ mod jwk_refresh_lock_try_acquire_tests {
     /// unsuccessful (false).
     ///
     /// # Test Setup
-    /// - Setup basic EsiClient
+    /// - Setup basic Client
     /// - Acquire a lock initially
     /// - Attempt to acquire lock again
     ///
@@ -476,11 +476,11 @@ mod jwk_refresh_lock_try_acquire_tests {
     ///   a second time indicating it is already in use.
     #[test]
     fn test_jwk_refresh_lock_try_acquire_unsuccessful() {
-        // Setup basic EsiClient
-        let esi_client = EsiClient::builder()
+        // Setup basic Client
+        let esi_client = Client::builder()
             .user_agent("MyApp/1.0 (contact@example.com)")
             .build()
-            .expect("Failed to build EsiClient");
+            .expect("Failed to build Client");
 
         // Acquire a lock initially
         let jwt_key_cache = &esi_client.jwt_key_cache;
@@ -506,7 +506,7 @@ mod jwk_refresh_lock_try_acquire_tests {
 mod jwk_lock_release_and_notify_tests {
     use std::time::Duration;
 
-    use crate::EsiClient;
+    use crate::Client;
 
     /// Verifies that lock is successfully released & waiters are notified
     ///
@@ -517,7 +517,7 @@ mod jwk_lock_release_and_notify_tests {
     /// without issues.
     ///
     /// # Test Setup
-    /// - Create a basic EsiClient
+    /// - Create a basic Client
     /// - Acquire a JWT key refresh lock
     /// - Setup a notification listener
     ///
@@ -527,11 +527,11 @@ mod jwk_lock_release_and_notify_tests {
     /// - Assert that lock has been properly released
     #[tokio::test]
     async fn test_jwk_refresh_lock_release_and_notify_success() {
-        // Setup basic EsiClient
-        let esi_client = EsiClient::builder()
+        // Setup basic Client
+        let esi_client = Client::builder()
             .user_agent("MyApp/1.0 (contact@example.com)")
             .build()
-            .expect("Failed to build EsiClient");
+            .expect("Failed to build Client");
 
         // Acquire a lock
         let jwt_key_cache = &esi_client.jwt_key_cache;
@@ -587,23 +587,23 @@ mod jwk_lock_release_and_notify_tests {
 
 #[cfg(test)]
 mod set_refresh_failure_tests {
-    use crate::EsiClient;
+    use crate::Client;
 
     /// Set the last refresh failure timestamp
     ///
     /// # Test Setup
-    /// - Create a basic EsiClient
+    /// - Create a basic Client
     ///
     /// # Assertions
     /// - Assert last refresh failure is Some
     /// - Assert failure time matches timestamp set
     #[tokio::test]
     async fn test_set_refresh_failure_some() {
-        // Setup basic EsiClient
-        let esi_client = EsiClient::builder()
+        // Setup basic Client
+        let esi_client = Client::builder()
             .user_agent("MyApp/1.0 (contact@example.com)")
             .build()
-            .expect("Failed to build EsiClient");
+            .expect("Failed to build Client");
 
         let jwt_key_cache = &esi_client.jwt_key_cache;
 
@@ -623,18 +623,18 @@ mod set_refresh_failure_tests {
     /// Set the last refresh failure timestamp to none
     ///
     /// # Test Setup
-    /// - Create a basic EsiClient
+    /// - Create a basic Client
     /// - Set a refresh failure timestamp
     ///
     /// # Assertions
     /// - Assert last refresh failure is None
     #[tokio::test]
     async fn test_set_refresh_failure_none() {
-        // Setup basic EsiClient
-        let esi_client = EsiClient::builder()
+        // Setup basic Client
+        let esi_client = Client::builder()
             .user_agent("MyApp/1.0 (contact@example.com)")
             .build()
-            .expect("Failed to build EsiClient");
+            .expect("Failed to build Client");
 
         let jwt_key_cache = &esi_client.jwt_key_cache;
 

--- a/src/oauth2/jwk/jwk.rs
+++ b/src/oauth2/jwk/jwk.rs
@@ -20,19 +20,19 @@ use crate::oauth2::jwk::util::{
     check_refresh_cooldown, is_cache_approaching_expiry, is_cache_expired,
 };
 use crate::oauth2::OAuth2Api;
-use crate::EsiClient;
+use crate::Client;
 
 /// Provides access to JWK endpoints & caching for EVE Online's OAuth2 endpoints
 ///
 /// The [`JwkApi`] acts as an interface for retrieving JWT keys, caching, and refreshing them
 /// when the keys are expired or nearing expiration.
 ///
-/// It requires an [`EsiClient`] which is used for making HTTP requests and it provides the
+/// It requires an [`Client`] which is used for making HTTP requests and it provides the
 /// JWT key cache used by the eve_esi crate's OAuth2 functionality for token validation.
 ///
 /// See the [module-level documentation](super) for an overview and usage example.
 pub struct JwkApi<'a> {
-    pub(super) client: &'a EsiClient,
+    pub(super) client: &'a Client,
 }
 
 impl OAuth2Api<'_> {
@@ -51,12 +51,12 @@ impl<'a> JwkApi<'a> {
     /// Creates a new instance of [`JwkApi`]
     ///
     /// # Arguments
-    /// - `client` (&'a [`EsiClient`]) used for making HTTP requests to EVE Online API endpoints
+    /// - `client` (&'a [`Client`]) used for making HTTP requests to EVE Online API endpoints
     ///   and providing the JWT key cache.
     ///
     /// # Returns
     /// - `Self`: A new instance of [`JwkApi`].
-    pub fn new(client: &'a EsiClient) -> Self {
+    pub fn new(client: &'a Client) -> Self {
         Self { client }
     }
 

--- a/src/oauth2/jwk/jwk.rs
+++ b/src/oauth2/jwk/jwk.rs
@@ -12,7 +12,7 @@
 use log::{debug, error};
 use std::time::Instant;
 
-use crate::error::{EsiError, OAuthError};
+use crate::error::{Error, OAuthError};
 use crate::model::oauth2::EveJwtKeys;
 use crate::oauth2::jwk::cache::JwtKeyCache;
 use crate::oauth2::jwk::refresh::refresh_jwt_keys;
@@ -88,7 +88,7 @@ impl<'a> JwkApi<'a> {
     ///
     /// # Errors
     /// - [`EsiError`]: Returns an error if the JWT key cache is empty and new keys could not be fetched.
-    pub async fn get_jwt_keys(&self) -> Result<EveJwtKeys, EsiError> {
+    pub async fn get_jwt_keys(&self) -> Result<EveJwtKeys, Error> {
         let esi_client = self.client;
         let jwt_key_cache = &esi_client.jwt_key_cache;
         let config = &jwt_key_cache.config;
@@ -149,7 +149,7 @@ impl<'a> JwkApi<'a> {
             #[cfg(not(tarpaulin_include))]
             error!("{}", error_message);
 
-            return Err(EsiError::OAuthError(OAuthError::JwtKeyRefreshCooldown(
+            return Err(Error::OAuthError(OAuthError::JwtKeyRefreshCooldown(
                 error_message,
             )));
         }
@@ -186,7 +186,7 @@ impl<'a> JwkApi<'a> {
     ///
     /// # Errors
     /// - [`EsiError::ReqwestError`]: If the request to fetch JWT keys fails.
-    pub async fn fetch_and_update_cache(&self) -> Result<EveJwtKeys, EsiError> {
+    pub async fn fetch_and_update_cache(&self) -> Result<EveJwtKeys, Error> {
         let esi_client = self.client;
 
         fetch_and_update_cache(&esi_client.reqwest_client, &esi_client.jwt_key_cache).await
@@ -206,7 +206,7 @@ impl<'a> JwkApi<'a> {
     ///
     /// # Errors
     /// - [`EsiError::ReqwestError`]: If the request to fetch JWT keys fails.
-    pub async fn fetch_jwt_keys(&self) -> Result<EveJwtKeys, EsiError> {
+    pub async fn fetch_jwt_keys(&self) -> Result<EveJwtKeys, Error> {
         let esi_client = self.client;
 
         fetch_jwt_keys(
@@ -237,7 +237,7 @@ impl<'a> JwkApi<'a> {
 pub(super) async fn fetch_jwt_keys(
     reqwest_client: &reqwest::Client,
     jwk_url: &str,
-) -> Result<EveJwtKeys, EsiError> {
+) -> Result<EveJwtKeys, Error> {
     #[cfg(not(tarpaulin_include))]
     debug!("Fetching JWT keys from EVE OAuth2 API: {}", jwk_url);
 
@@ -328,7 +328,7 @@ pub(super) async fn fetch_jwt_keys(
 pub(super) async fn fetch_and_update_cache(
     reqwest_client: &reqwest::Client,
     jwt_key_cache: &JwtKeyCache,
-) -> Result<EveJwtKeys, EsiError> {
+) -> Result<EveJwtKeys, Error> {
     #[cfg(not(tarpaulin_include))]
     debug!("Fetching fresh JWT keys and updating cache");
 

--- a/src/oauth2/jwk/refresh.rs
+++ b/src/oauth2/jwk/refresh.rs
@@ -15,7 +15,7 @@ use std::time::Instant;
 use ::tokio::time::Duration;
 use log::{debug, error, info, trace};
 
-use crate::error::{EsiError, OAuthError};
+use crate::error::{Error, OAuthError};
 use crate::model::oauth2::EveJwtKeys;
 use crate::oauth2::jwk::cache::JwtKeyCache;
 
@@ -48,7 +48,7 @@ impl<'a> JwkApi<'a> {
     /// - Ok([`EveJwtKeys`]) if the refresh was successful and keys are now in the cache
     /// - Err([`EsiError`]) if the refresh attempt failed or timed out after
     ///   [`DEFAULT_JWK_REFRESH_TIMEOUT`] seconds (5 seconds)
-    pub(super) async fn wait_for_ongoing_refresh(&self) -> Result<EveJwtKeys, EsiError> {
+    pub(super) async fn wait_for_ongoing_refresh(&self) -> Result<EveJwtKeys, Error> {
         let esi_client = self.client;
         let jwt_key_cache = &esi_client.jwt_key_cache;
         let config = &jwt_key_cache.config;
@@ -82,7 +82,7 @@ impl<'a> JwkApi<'a> {
             debug!("{}", error_message);
 
             // Return error indicating function timed out waiting JWT key refresh
-            return Err(EsiError::OAuthError(OAuthError::JwtKeyRefreshTimeout(
+            return Err(Error::OAuthError(OAuthError::JwtKeyRefreshTimeout(
                 error_message,
             )));
         }
@@ -113,7 +113,7 @@ impl<'a> JwkApi<'a> {
         debug!("{}", error_message);
 
         // Return an error indicating no keys were found in cache
-        Err(EsiError::OAuthError(OAuthError::JwtKeyRefreshFailure(
+        Err(Error::OAuthError(OAuthError::JwtKeyRefreshFailure(
             error_message,
         )))
     }
@@ -220,7 +220,7 @@ pub(super) async fn refresh_jwt_keys(
     reqwest_client: &reqwest::Client,
     jwt_key_cache: &JwtKeyCache,
     max_retries: u32,
-) -> Result<EveJwtKeys, EsiError> {
+) -> Result<EveJwtKeys, Error> {
     let config = &jwt_key_cache.config;
 
     // Track operation timing for performance monitoring
@@ -314,7 +314,7 @@ pub(super) async fn refresh_jwt_keys(
 
 #[cfg(test)]
 mod wait_for_ongoing_refresh_tests {
-    use crate::error::EsiError;
+    use crate::error::Error;
     use crate::model::oauth2::EveJwtKeys;
     use crate::oauth2::error::OAuthError;
     use crate::tests::setup;
@@ -455,7 +455,7 @@ mod wait_for_ongoing_refresh_tests {
         // Assert function returned expected error
         assert!(result.is_err());
         match result {
-            Err(EsiError::OAuthError(OAuthError::JwtKeyRefreshFailure(_))) => {}
+            Err(Error::OAuthError(OAuthError::JwtKeyRefreshFailure(_))) => {}
             _ => panic!("Expected OAuthError::JwtKeyRefreshFailure, got different error type"),
         }
     }
@@ -536,7 +536,7 @@ mod wait_for_ongoing_refresh_tests {
         // Assert function returned expected error
         assert!(result.is_err());
         match result {
-            Err(EsiError::OAuthError(OAuthError::JwtKeyRefreshFailure(_))) => {}
+            Err(Error::OAuthError(OAuthError::JwtKeyRefreshFailure(_))) => {}
             _ => panic!("Expected OAuthError::JwtKeyRefreshFailure, got different error type"),
         }
     }
@@ -584,7 +584,7 @@ mod wait_for_ongoing_refresh_tests {
         // Assert function returned expected error
         assert!(result.is_err());
         match result {
-            Err(EsiError::OAuthError(OAuthError::JwtKeyRefreshTimeout(_))) => {}
+            Err(Error::OAuthError(OAuthError::JwtKeyRefreshTimeout(_))) => {}
             _ => panic!("Expected OAuthError::JwtKeyCacheError, got different error type"),
         }
     }
@@ -699,7 +699,7 @@ mod trigger_background_jwt_refresh_test {
 #[cfg(test)]
 mod refresh_jwt_keys_tests {
     use crate::tests::setup;
-    use crate::{error::EsiError, oauth2::jwk::refresh::refresh_jwt_keys};
+    use crate::{error::Error, oauth2::jwk::refresh::refresh_jwt_keys};
 
     use super::super::tests::{get_jwk_internal_server_error_response, get_jwk_success_response};
 
@@ -783,7 +783,7 @@ mod refresh_jwt_keys_tests {
         // Assert function returned expected error
         assert!(result.is_err());
         match result {
-            Err(EsiError::ReqwestError(err)) => {
+            Err(Error::ReqwestError(err)) => {
                 // Ensure reqwest error is of type 500 server error
                 assert!(err.is_status());
                 assert_eq!(

--- a/src/oauth2/login.rs
+++ b/src/oauth2/login.rs
@@ -7,7 +7,7 @@
 
 use oauth2::{CsrfToken, Scope};
 
-use crate::error::{EsiError, OAuthError};
+use crate::error::{Error, OAuthError};
 use crate::model::oauth2::AuthenticationData;
 use crate::oauth2::OAuth2Api;
 
@@ -58,13 +58,13 @@ impl<'a> OAuth2Api<'a> {
     /// // Print the created login URL
     /// println!("Login URL: {}", auth_data.login_url);
     /// ```
-    pub fn login_url(&self, scopes: Vec<String>) -> Result<AuthenticationData, EsiError> {
+    pub fn login_url(&self, scopes: Vec<String>) -> Result<AuthenticationData, Error> {
         // Retrieve the OAuth2 client from the EsiClient
         let client = match &self.client.oauth2_client {
             Some(client) => client,
             // Returns an error if the OAuth2 client is not found due to it not having been configured when
             // building the EsiClient.
-            None => return Err(EsiError::OAuthError(OAuthError::OAuth2NotConfigured)),
+            None => return Err(Error::OAuthError(OAuthError::OAuth2NotConfigured)),
         };
 
         // Convert the Vec<String> of scopes into Vec<Scope>
@@ -86,7 +86,7 @@ impl<'a> OAuth2Api<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::error::{EsiError, OAuthError};
+    use crate::error::{Error, OAuthError};
     use crate::oauth2::ScopeBuilder;
 
     /// Tests the successful generation of an OAuth2 login URL and CSRF state token.
@@ -147,7 +147,7 @@ mod tests {
 
         // Ensure error is of type EsiError::OAuthError(OAuthError::OAuth2NotConfigured)
         match result {
-            Err(EsiError::OAuthError(OAuthError::OAuth2NotConfigured)) => {},
+            Err(Error::OAuthError(OAuthError::OAuth2NotConfigured)) => {},
             err => panic!("Expected EsiError::OAuthError(OAuthError::OAuth2NotConfigured), instead received: {:#?}", err),
         }
     }

--- a/src/oauth2/login.rs
+++ b/src/oauth2/login.rs
@@ -16,7 +16,7 @@ impl<'a> OAuth2Api<'a> {
     ///
     /// This method constructs the URL that begins the login process for EVE Online SSO (single sign-on) or also known as OAuth2.
     /// After successful authentication, EVE Online will redirect the user to the callback URL (`callback_url`) specified
-    /// in your [`EsiClient`](crate::EsiClient) configuration with an authorization code used to request an access token with the
+    /// in your [`Client`](crate::Client) configuration with an authorization code used to request an access token with the
     /// [crate::oauth2::OAuth2Api::get_token] method.
     ///
     /// # Arguments
@@ -30,19 +30,19 @@ impl<'a> OAuth2Api<'a> {
     ///
     /// # Errors
     /// Returns an [`EsiError`] if:
-    /// - The `client_id`, `client_secret`, and `callback_url` is missing from the [`EsiClient`](crate::EsiClient) configuration
+    /// - The `client_id`, `client_secret`, and `callback_url` is missing from the [`Client`](crate::Client) configuration
     ///   which results in an [`OAuthError::OAuth2NotConfigured`] error.
     ///
     /// # Example
     /// ```
-    /// // Configure EsiClient for OAuth2 with a client_id, client_secret, and callback_url
-    /// let esi_client = eve_esi::EsiClient::builder()
+    /// // Configure Client for OAuth2 with a client_id, client_secret, and callback_url
+    /// let esi_client = eve_esi::Client::builder()
     ///     .user_agent("MyApp/1.0 (contact@example.com)")
     ///     .client_id("client_id")
     ///     .client_secret("client_secret")
     ///     .callback_url("http://localhost:8080/callback")
     ///     .build()
-    ///     .expect("Failed to build EsiClient");
+    ///     .expect("Failed to build Client");
     ///
     /// // Build scopes requesting only publicData
     /// let scopes = eve_esi::oauth2::ScopeBuilder::new()
@@ -59,11 +59,11 @@ impl<'a> OAuth2Api<'a> {
     /// println!("Login URL: {}", auth_data.login_url);
     /// ```
     pub fn login_url(&self, scopes: Vec<String>) -> Result<AuthenticationData, Error> {
-        // Retrieve the OAuth2 client from the EsiClient
+        // Retrieve the OAuth2 client from the Client
         let client = match &self.client.oauth2_client {
             Some(client) => client,
             // Returns an error if the OAuth2 client is not found due to it not having been configured when
-            // building the EsiClient.
+            // building the Client.
             None => return Err(Error::OAuthError(OAuthError::OAuth2NotConfigured)),
         };
 
@@ -92,7 +92,7 @@ mod tests {
     /// Tests the successful generation of an OAuth2 login URL and CSRF state token.
     ///
     /// # Test Setup
-    /// - Configure [`EsiClient`](crate::EsiClient) for OAuth2 with a client_id, client_secret, and callback_url
+    /// - Configure [`Client`](crate::Client) for OAuth2 with a client_id, client_secret, and callback_url
     /// - Build scopes requesting only publicData
     ///
     /// # Assertions
@@ -100,14 +100,14 @@ mod tests {
     ///   confirming that proper CSRF protection is in place
     #[test]
     fn test_successful_login_url() {
-        // Configure EsiClient for OAuth2 with a client_id, client_secret, and callback_url
-        let esi_client = crate::EsiClient::builder()
+        // Configure Client for OAuth2 with a client_id, client_secret, and callback_url
+        let esi_client = crate::Client::builder()
             .user_agent("MyApp/1.0 (contact@example.com)")
             .client_id("client_id")
             .client_secret("client_secret")
             .callback_url("http://localhost:8080/callback")
             .build()
-            .expect("Failed to build EsiClient");
+            .expect("Failed to build Client");
 
         // Build scopes requesting only publicData
         let scopes = ScopeBuilder::new().public_data().build();
@@ -122,7 +122,7 @@ mod tests {
     /// Ensures the proper error is received when attempting to generate a login url without configuring OAuth2
     ///
     /// # Test Setup
-    /// - Create an [`EsiClient`](crate::EsiClient) without setting the client_id, client_secret, or callback_url
+    /// - Create an [`Client`](crate::Client) without setting the client_id, client_secret, or callback_url
     /// - Build scopes requesting only publicData
     ///
     /// # Assertions
@@ -131,10 +131,10 @@ mod tests {
     #[test]
     fn test_oauth_client_not_configured() {
         // Create an ESI client without setting the client_id, client_secret, or callback_url
-        let esi_client = crate::EsiClient::builder()
+        let esi_client = crate::Client::builder()
             .user_agent("MyApp/1.0 (contact@example.com)")
             .build()
-            .expect("Failed to build EsiClient");
+            .expect("Failed to build Client");
 
         // Build scopes requesting only publicData
         let scopes = ScopeBuilder::new().public_data().build();

--- a/src/oauth2/mod.rs
+++ b/src/oauth2/mod.rs
@@ -21,13 +21,13 @@
 //!
 //! # Example
 //! ```
-//! let esi_client = eve_esi::EsiClient::builder()
+//! let esi_client = eve_esi::Client::builder()
 //!     .user_agent("MyApp/1.0 (contact@example.com)")
 //!     .client_id("client_id")
 //!     .client_secret("client_secret")
 //!     .callback_url("http://localhost:8080/callback")
 //!     .build()
-//!     .expect("Failed to build EsiClient");
+//!     .expect("Failed to build Client");
 //!
 //! // Build scopes requesting only publicData
 //! let scopes = eve_esi::oauth2::ScopeBuilder::new()

--- a/src/oauth2/oauth2.rs
+++ b/src/oauth2/oauth2.rs
@@ -1,37 +1,37 @@
-//! Provides [`OAuth2Api`] for accessing OAuth2 related methods for the [`EsiClient`]
+//! Provides [`OAuth2Api`] for accessing OAuth2 related methods for the [`Client`]
 //!
 //! The [`OAuth2Api`] struct provides access to oauth2 related methods for
-//! the [`EsiClient`] using the [`EsiClient::oauth2`] method.
+//! the [`Client`] using the [`Client::oauth2`] method.
 //!
 //! For more details regarding using OAuth2 with the eve_esi crate, see [module-level documentation](super)
 
-use crate::EsiClient;
+use crate::Client;
 
 /// Provides methods for accessing OAuth2-related endpoints of EVE Online's API.
 ///
 /// The [`OAuth2Api`] struct acts as an interface for retrieving data from EVE Online's OAuth2 endpoints
-/// It requires an [`EsiClient`] for making HTTP requests to the endpoints and managing JWT keys to validate tokens.
+/// It requires an [`Client`] for making HTTP requests to the endpoints and managing JWT keys to validate tokens.
 ///
 /// See the [module-level documentation](self) for an overview and usage example.
 pub struct OAuth2Api<'a> {
-    pub(super) client: &'a EsiClient,
+    pub(super) client: &'a Client,
 }
 
 impl<'a> OAuth2Api<'a> {
     /// Creates a new instance of [`OAuth2Api`]
     ///
     /// # Arguments
-    /// - `client` (&'a [`EsiClient`]) used for making HTTP requests to EVE Online API endpoints
+    /// - `client` (&'a [`Client`]) used for making HTTP requests to EVE Online API endpoints
     ///   and providing the JWT key cache.
     ///
     /// # Returns
     /// - `Self`: A new instance of [`OAuth2Api`].
-    pub fn new(client: &'a EsiClient) -> Self {
+    pub fn new(client: &'a Client) -> Self {
         Self { client }
     }
 }
 
-impl EsiClient {
+impl Client {
     /// Access to EVE Online's OAuth2 endpoints
     ///
     /// Returns an API client for interacting with the OAuth2 endpoints.

--- a/src/oauth2/token.rs
+++ b/src/oauth2/token.rs
@@ -3,7 +3,7 @@
 use oauth2::basic::BasicTokenType;
 use oauth2::{AuthorizationCode, EmptyExtraTokenFields, StandardTokenResponse};
 
-use crate::error::{EsiError, OAuthError};
+use crate::error::{Error, OAuthError};
 use crate::oauth2::OAuth2Api;
 
 impl<'a> OAuth2Api<'a> {
@@ -47,10 +47,10 @@ impl<'a> OAuth2Api<'a> {
     pub async fn get_token(
         &self,
         code: &str,
-    ) -> Result<StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType>, EsiError> {
+    ) -> Result<StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType>, Error> {
         let client = match &self.client.oauth2_client {
             Some(client) => client,
-            None => return Err(EsiError::OAuthError(OAuthError::OAuth2NotConfigured)),
+            None => return Err(Error::OAuthError(OAuthError::OAuth2NotConfigured)),
         };
 
         match client
@@ -59,7 +59,7 @@ impl<'a> OAuth2Api<'a> {
             .await
         {
             Ok(token) => Ok(token),
-            Err(err) => Err(EsiError::OAuthError(OAuthError::TokenError(err))),
+            Err(err) => Err(Error::OAuthError(OAuthError::TokenError(err))),
         }
     }
 }

--- a/src/oauth2/token.rs
+++ b/src/oauth2/token.rs
@@ -9,7 +9,7 @@ use crate::oauth2::OAuth2Api;
 impl<'a> OAuth2Api<'a> {
     /// Retrieves a token from EVE Online's OAuth2 API.
     ///
-    /// This method uses the configured EsiClient to retrieve a token from EVE Online's
+    /// This method uses the configured Client to retrieve a token from EVE Online's
     /// OAuth2 API using the provided authorization code. This will contain both your
     /// access token and refresh token.
     ///
@@ -17,20 +17,20 @@ impl<'a> OAuth2Api<'a> {
     /// ```no_run
     /// #[tokio::main]
     /// async fn main() {
-    ///     use eve_esi::EsiClient;
+    ///     use eve_esi::Client;
     ///     use oauth2::TokenResponse;
     ///
     ///     // You can get the authorization code as a query parameter in your callback API route
     ///     // when a user is redirected back to your application after authorization.
     ///     let authorization_code = "authorization_code";
     ///
-    ///     let esi_client = EsiClient::builder()
+    ///     let esi_client = Client::builder()
     ///         .user_agent("MyApp/1.0 (contact@example.com)")
     ///         .client_id("client_id")
     ///         .client_secret("client_secret")
     ///         .callback_url("http://localhost:8080/callback")
     ///         .build()
-    ///         .expect("Failed to build EsiClient");
+    ///         .expect("Failed to build Client");
     ///
     ///     let token = esi_client
     ///         .oauth2()

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -2,15 +2,15 @@ use std::time::Duration;
 
 use mockito::{Server, ServerGuard};
 
-use crate::config::EsiConfig;
+use crate::config::Config;
 use crate::Client;
 
 /// Utility function to create initial test setup for all HTTP-related unit tests
 ///
 /// # Setup
 /// - Create a mock server using the [`mockito`] crate to handle HTTP requests at mock endpoints
-/// - Create an [`EsiConfig`] with the `jwk_url` set to the mock server & reduced wait times
-/// - Create an Client using the custom [`EsiConfig`]
+/// - Create an [`Config`] with the `jwk_url` set to the mock server & reduced wait times
+/// - Create an Client using the custom [`Config`]
 ///
 /// # Returns
 /// A tuple containing:
@@ -22,14 +22,14 @@ pub(crate) async fn setup() -> (Client, ServerGuard) {
     let mock_server_url = mock_server.url();
 
     // Create a config with mock server JWK URL & reduced wait times
-    let config = EsiConfig::builder()
+    let config = Config::builder()
         .jwk_url(&format!("{}/oauth/jwks", mock_server_url))
         // Set exponential backoff between refresh retries to 1 millisecond
         .jwk_refresh_backoff(Duration::from_millis(1))
         // Set timeout to 1 second when waiting for another thread to refresh
         .jwk_refresh_timeout(Duration::from_secs(1))
         .build()
-        .expect("Failed to build EsiConfig");
+        .expect("Failed to build Config");
 
     // Create ESI client with the custom config
     let esi_client = Client::builder()

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -3,20 +3,20 @@ use std::time::Duration;
 use mockito::{Server, ServerGuard};
 
 use crate::config::EsiConfig;
-use crate::EsiClient;
+use crate::Client;
 
 /// Utility function to create initial test setup for all HTTP-related unit tests
 ///
 /// # Setup
 /// - Create a mock server using the [`mockito`] crate to handle HTTP requests at mock endpoints
 /// - Create an [`EsiConfig`] with the `jwk_url` set to the mock server & reduced wait times
-/// - Create an EsiClient using the custom [`EsiConfig`]
+/// - Create an Client using the custom [`EsiConfig`]
 ///
 /// # Returns
 /// A tuple containing:
-/// - [`eve_esi::EsiClient`]: A basic EsiClient with jwk_url set to the mock server
+/// - [`eve_esi::Client`]: A basic Client with jwk_url set to the mock server
 /// - [`mockito::ServerGuard`]: A mock server for handling http requests for test purposes
-pub(crate) async fn setup() -> (EsiClient, ServerGuard) {
+pub(crate) async fn setup() -> (Client, ServerGuard) {
     // Setup mock server
     let mock_server = Server::new_async().await;
     let mock_server_url = mock_server.url();
@@ -32,11 +32,11 @@ pub(crate) async fn setup() -> (EsiClient, ServerGuard) {
         .expect("Failed to build EsiConfig");
 
     // Create ESI client with the custom config
-    let esi_client = EsiClient::builder()
+    let esi_client = Client::builder()
         .user_agent("MyApp/1.0 (contact@example.com)")
         .config(config)
         .build()
-        .expect("Failed to build EsiClient");
+        .expect("Failed to build Client");
 
     (esi_client, mock_server)
 }

--- a/tests/endpoints/alliance/get_alliance_information.rs
+++ b/tests/endpoints/alliance/get_alliance_information.rs
@@ -1,4 +1,3 @@
-use eve_esi::error::EsiError;
 use eve_esi::model::alliance::Alliance;
 
 use crate::util::setup;
@@ -90,7 +89,7 @@ async fn get_alliance_information_not_found() {
     // Assert result is error
     assert!(result.is_err());
     match result {
-        Err(EsiError::ReqwestError(err)) => {
+        Err(eve_esi::Error::ReqwestError(err)) => {
             // Assert reqwest error is due to status NOT_FOUND
             assert!(err.status().is_some());
             assert_eq!(err.status().unwrap(), reqwest::StatusCode::NOT_FOUND);

--- a/tests/endpoints/character/character_affiliation.rs
+++ b/tests/endpoints/character/character_affiliation.rs
@@ -1,4 +1,3 @@
-use eve_esi::error::EsiError;
 use eve_esi::model::character::CharacterAffiliation;
 
 use crate::util::setup;
@@ -96,7 +95,7 @@ async fn character_affiliation_bad_request() {
     // Assert result is error
     assert!(result.is_err());
     match result {
-        Err(EsiError::ReqwestError(err)) => {
+        Err(eve_esi::Error::ReqwestError(err)) => {
             // Assert reqwest error is due to status BAD_REQUEST
             assert!(err.status().is_some());
             assert_eq!(err.status().unwrap(), reqwest::StatusCode::BAD_REQUEST);

--- a/tests/endpoints/character/get_character_public_information.rs
+++ b/tests/endpoints/character/get_character_public_information.rs
@@ -1,4 +1,3 @@
-use eve_esi::error::EsiError;
 use eve_esi::model::character::Character;
 
 use crate::util::setup;
@@ -94,7 +93,7 @@ async fn get_character_public_information_not_found() {
     // Assert result is error
     assert!(result.is_err());
     match result {
-        Err(EsiError::ReqwestError(err)) => {
+        Err(eve_esi::Error::ReqwestError(err)) => {
             // Assert reqwest error is due to status NOT_FOUND
             assert!(err.status().is_some());
             assert_eq!(err.status().unwrap(), reqwest::StatusCode::NOT_FOUND);

--- a/tests/endpoints/corporation/get_corporation_information.rs
+++ b/tests/endpoints/corporation/get_corporation_information.rs
@@ -1,4 +1,3 @@
-use eve_esi::error::EsiError;
 use eve_esi::model::corporation::Corporation;
 
 use crate::util::setup;
@@ -97,7 +96,7 @@ async fn get_corporation_not_found() {
     // Assert result is error
     assert!(result.is_err());
     match result {
-        Err(EsiError::ReqwestError(err)) => {
+        Err(eve_esi::Error::ReqwestError(err)) => {
             // Assert reqwest error is due to status NOT_FOUND
             assert!(err.status().is_some());
             assert_eq!(err.status().unwrap(), reqwest::StatusCode::NOT_FOUND);

--- a/tests/oauth2/jwk/fetch_and_update_cache.rs
+++ b/tests/oauth2/jwk/fetch_and_update_cache.rs
@@ -1,5 +1,3 @@
-use eve_esi::error::EsiError;
-
 use super::util::{get_jwk_internal_server_error_response, get_jwk_success_response};
 use crate::util::setup;
 
@@ -56,7 +54,7 @@ async fn test_fetch_and_update_cache_request_error() {
     // Assert result is error
     assert!(result.is_err());
     match result {
-        Err(EsiError::ReqwestError(err)) => {
+        Err(eve_esi::Error::ReqwestError(err)) => {
             // Assert error is reqwest error of type 500 internal server error
             assert!(err.is_status());
             assert_eq!(

--- a/tests/oauth2/jwk/fetch_jwt_keys.rs
+++ b/tests/oauth2/jwk/fetch_jwt_keys.rs
@@ -1,5 +1,5 @@
 use eve_esi::model::oauth2::EveJwtKey;
-use eve_esi::{EsiClient, EsiConfig};
+use eve_esi::{Client, EsiConfig};
 
 use super::util::{get_jwk_internal_server_error_response, get_jwk_success_response};
 use crate::util::setup;
@@ -7,7 +7,7 @@ use crate::util::setup;
 /// Tests the successful retrieval of JWT keys from a mock EVE SSO server.
 ///
 /// # Test Setup
-/// - Create a basic EsiClient & mock HTTP server
+/// - Create a basic Client & mock HTTP server
 /// - Configures a mock success response with expected JWT keys
 ///
 /// # Assertions
@@ -17,7 +17,7 @@ use crate::util::setup;
 /// - Assert we have at least 1 key of expected type
 #[tokio::test]
 async fn fetch_jwt_keys_success() {
-    // Setup a basic EsiClient & mock HTTP server
+    // Setup a basic Client & mock HTTP server
     let (esi_client, mut mock_server) = setup().await;
 
     // Create mock response with mock keys & expecting 1 request
@@ -56,7 +56,7 @@ async fn fetch_jwt_keys_success() {
 /// Tests error handling when retrieving JWT keys from a failing EVE SSO server.
 ///
 /// # Test Setup
-/// - Create a basic EsiClient & mock HTTP server
+/// - Create a basic Client & mock HTTP server
 /// - Configures a mock response returning an error 500 and expecting 1 request
 ///
 /// # Assertions
@@ -65,7 +65,7 @@ async fn fetch_jwt_keys_success() {
 /// - Assert error is of type [`reqwest::StatusCode::INTERNAL_SERVER_ERROR`]
 #[tokio::test]
 async fn fetch_jwt_keys_server_error() {
-    // Setup a basic EsiClient & mock HTTP server
+    // Setup a basic Client & mock HTTP server
     let (esi_client, mut mock_server) = setup().await;
 
     // Create mock response with error 500 and expecting 1 request
@@ -98,7 +98,7 @@ async fn fetch_jwt_keys_server_error() {
 /// # Test Setup
 /// - Create a custom OAuth2 config with the JWK URL set to an invalid endpoint
 /// - Create a reqwest client with reduced timeout
-/// - Create an EsiClient with the custom OAuth2 config and reqwest client
+/// - Create an Client with the custom OAuth2 config and reqwest client
 ///
 /// # Assertions
 /// - Assert result is error
@@ -119,12 +119,12 @@ async fn fetch_jwt_keys_network_error() {
         .expect("Failed to build reqwest Client");
 
     // Create ESI client with the custom config & reqwest client
-    let esi_client = EsiClient::builder()
+    let esi_client = Client::builder()
         .config(config)
         .user_agent("MyApp/1.0 (contact@example.com)")
         .reqwest_client(reqwest_client)
         .build()
-        .expect("Failed to build EsiClient");
+        .expect("Failed to build Client");
 
     // Call the fetch_jwt_keys method
     let result = esi_client.oauth2().jwk().fetch_jwt_keys().await;
@@ -149,7 +149,7 @@ async fn fetch_jwt_keys_network_error() {
 /// Tests error handling when server returns an invalid response body
 ///
 /// # Test Setup
-/// - Create a basic EsiClient & mock HTTP server
+/// - Create a basic Client & mock HTTP server
 /// - Configures a mock success response with an unexpected response body
 ///
 /// # Assertions
@@ -158,7 +158,7 @@ async fn fetch_jwt_keys_network_error() {
 /// - Assert error is of type [`reqwest::error::Kind::Decode`]
 #[tokio::test]
 async fn fetch_jwt_keys_parse_error() {
-    // Setup a basic EsiClient & mock HTTP server
+    // Setup a basic Client & mock HTTP server
     let (esi_client, mut mock_server) = setup().await;
 
     // Create mock success response with unexpected body

--- a/tests/oauth2/jwk/fetch_jwt_keys.rs
+++ b/tests/oauth2/jwk/fetch_jwt_keys.rs
@@ -1,5 +1,4 @@
 use eve_esi::model::oauth2::EveJwtKey;
-use eve_esi::{Client, EsiConfig};
 
 use super::util::{get_jwk_internal_server_error_response, get_jwk_success_response};
 use crate::util::setup;
@@ -106,10 +105,10 @@ async fn fetch_jwt_keys_server_error() {
 #[tokio::test]
 async fn fetch_jwt_keys_network_error() {
     // Create config with a JWK URL that won't respond
-    let config = EsiConfig::builder()
+    let config = eve_esi::Config::builder()
         .jwk_url("http://10.255.255.1") // RFC 5735 TEST‑NET‑2 range
         .build()
-        .expect("Failed to build EsiConfig cache");
+        .expect("Failed to build Config cache");
 
     // Create reqwest::Client with reduced connect timeout
     let timeout = std::time::Duration::from_millis(100);
@@ -119,7 +118,7 @@ async fn fetch_jwt_keys_network_error() {
         .expect("Failed to build reqwest Client");
 
     // Create ESI client with the custom config & reqwest client
-    let esi_client = Client::builder()
+    let esi_client = eve_esi::Client::builder()
         .config(config)
         .user_agent("MyApp/1.0 (contact@example.com)")
         .reqwest_client(reqwest_client)

--- a/tests/oauth2/jwk/fetch_jwt_keys.rs
+++ b/tests/oauth2/jwk/fetch_jwt_keys.rs
@@ -1,6 +1,5 @@
 use eve_esi::model::oauth2::EveJwtKey;
-use eve_esi::EsiClient;
-use eve_esi::{config::EsiConfig, error::EsiError};
+use eve_esi::{EsiClient, EsiConfig};
 
 use super::util::{get_jwk_internal_server_error_response, get_jwk_success_response};
 use crate::util::setup;
@@ -82,7 +81,7 @@ async fn fetch_jwt_keys_server_error() {
     assert!(result.is_err());
 
     match result {
-        Err(EsiError::ReqwestError(err)) => {
+        Err(eve_esi::Error::ReqwestError(err)) => {
             // Assert error is reqwest error of type 500 internal server error
             assert!(err.is_status());
             assert_eq!(
@@ -134,7 +133,7 @@ async fn fetch_jwt_keys_network_error() {
     assert!(result.is_err());
 
     match result {
-        Err(EsiError::ReqwestError(err)) => {
+        Err(eve_esi::Error::ReqwestError(err)) => {
             // Assert reqwest error is related to a connection issue
             assert!(err.is_connect())
         }
@@ -180,7 +179,7 @@ async fn fetch_jwt_keys_parse_error() {
     assert!(result.is_err());
 
     match result {
-        Err(EsiError::ReqwestError(err)) => {
+        Err(eve_esi::Error::ReqwestError(err)) => {
             // Assert reqwest error is related to decoding the body
             assert!(err.is_decode())
         }

--- a/tests/oauth2/jwk/get_jwt_keys.rs
+++ b/tests/oauth2/jwk/get_jwt_keys.rs
@@ -1,7 +1,5 @@
 use std::time::Duration;
 
-use eve_esi::error::{EsiError, OAuthError};
-
 use super::util::{get_jwk_internal_server_error_response, get_jwk_success_response};
 use crate::util::setup;
 
@@ -144,8 +142,11 @@ async fn get_jwt_keys_refresh_cooldown() {
     assert!(result.is_err());
     match result {
         // Assert error is of the OAuthError:JwtKeyRefreshCooldown variant
-        Err(EsiError::OAuthError(OAuthError::JwtKeyRefreshCooldown(_))) => {}
-        _ => panic!("Expected OAuthError::JwtKeyRefreshCooldown error"),
+        Err(eve_esi::Error::OAuthError(eve_esi::OAuthError::JwtKeyRefreshCooldown(_))) => {}
+        err => panic!(
+            "Expected OAuthError::JwtKeyRefreshCooldown error, recieved: {:#?}.",
+            err
+        ),
     }
 }
 

--- a/tests/oauth2/token/get_token.rs
+++ b/tests/oauth2/token/get_token.rs
@@ -1,6 +1,3 @@
-use eve_esi::config::EsiConfig;
-use eve_esi::error::{EsiError, OAuthError};
-use eve_esi::EsiClient;
 use mockito::Server;
 use oauth2::RequestTokenError;
 
@@ -67,8 +64,9 @@ pub async fn test_get_token_error() {
     mock.assert();
     match result {
         Ok(_) => panic!("Expected an error"),
-        Err(EsiError::OAuthError(OAuthError::TokenError(RequestTokenError::ServerResponse(_)))) => {
-        }
+        Err(eve_esi::Error::OAuthError(eve_esi::OAuthError::TokenError(
+            RequestTokenError::ServerResponse(_),
+        ))) => {}
         Err(err) => panic!("Expected error of type EsiError::ReqwestError: {}", err),
     }
 }
@@ -99,12 +97,12 @@ pub async fn test_get_token_oauth_client_missing() {
         .create();
 
     // Create ESI client without OAuth2 config & with mock token endpoint
-    let config = EsiConfig::builder()
+    let config = eve_esi::EsiConfig::builder()
         .token_url(&format!("{}/v2/oauth/token", mock_server.url()))
         .build()
         .expect("Failed to build EsiConfig");
 
-    let esi_client = EsiClient::builder()
+    let esi_client = eve_esi::EsiClient::builder()
         .user_agent("MyApp/1.0 (contact@example.com)")
         .config(config)
         .build()
@@ -117,7 +115,7 @@ pub async fn test_get_token_oauth_client_missing() {
     mock.assert();
     match result {
         Ok(_) => panic!("Expected an error"),
-        Err(EsiError::OAuthError(OAuthError::OAuth2NotConfigured)) => {}
+        Err(eve_esi::Error::OAuthError(eve_esi::OAuthError::OAuth2NotConfigured)) => {}
         Err(_) => {
             panic!("Expected error of type EsiError::OAuthError(OAuthError::OAuth2NotConfigured)")
         }

--- a/tests/oauth2/token/get_token.rs
+++ b/tests/oauth2/token/get_token.rs
@@ -97,10 +97,10 @@ pub async fn test_get_token_oauth_client_missing() {
         .create();
 
     // Create ESI client without OAuth2 config & with mock token endpoint
-    let config = eve_esi::EsiConfig::builder()
+    let config = eve_esi::Config::builder()
         .token_url(&format!("{}/v2/oauth/token", mock_server.url()))
         .build()
-        .expect("Failed to build EsiConfig");
+        .expect("Failed to build Config");
 
     let esi_client = eve_esi::Client::builder()
         .user_agent("MyApp/1.0 (contact@example.com)")

--- a/tests/oauth2/token/get_token.rs
+++ b/tests/oauth2/token/get_token.rs
@@ -7,7 +7,7 @@ use crate::util::setup;
 /// Tests the successful retrieval of an OAuth2 token
 ///
 /// # Setup
-/// - Create an EsiClient configured with OAuth2 and a mock server
+/// - Create an Client configured with OAuth2 and a mock server
 /// - Configures a mock response with a successful token response
 ///
 /// # Assertions
@@ -15,7 +15,7 @@ use crate::util::setup;
 /// - Verifies that the token response is successful
 #[tokio::test]
 pub async fn test_get_token_success() {
-    // Create EsiClient configured with OAuth2 & mock server
+    // Create Client configured with OAuth2 & mock server
     let (client, mut mock_server) = setup().await;
 
     // Create mock response
@@ -39,7 +39,7 @@ pub async fn test_get_token_success() {
 /// Tests error handling when failing to retrieve an OAuth2 token
 ///
 /// # Setup
-/// - Create an EsiClient configured with OAuth2 and a mock server
+/// - Create an Client configured with OAuth2 and a mock server
 /// - Configures a mock response with a bad request status code
 ///
 /// # Assertions
@@ -47,7 +47,7 @@ pub async fn test_get_token_success() {
 /// - Verifies that the error is of the [`RequestTokenError::ServerResponse`] type
 #[tokio::test]
 pub async fn test_get_token_error() {
-    // Create EsiClient configured with OAuth2 & mock server
+    // Create Client configured with OAuth2 & mock server
     let (client, mut mock_server) = setup().await;
 
     // Create mock response
@@ -102,11 +102,11 @@ pub async fn test_get_token_oauth_client_missing() {
         .build()
         .expect("Failed to build EsiConfig");
 
-    let esi_client = eve_esi::EsiClient::builder()
+    let esi_client = eve_esi::Client::builder()
         .user_agent("MyApp/1.0 (contact@example.com)")
         .config(config)
         .build()
-        .expect("Failed to build EsiClient");
+        .expect("Failed to build Client");
 
     // Call the get_token method
     let result = esi_client.oauth2().get_token("authorization_code").await;

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use eve_esi::config::EsiConfig;
-use eve_esi::EsiClient;
+use eve_esi::Client;
 use mockito::{Server, ServerGuard};
 
 /// Utility function to create initial test setup for all jwk integration tests
@@ -9,13 +9,13 @@ use mockito::{Server, ServerGuard};
 /// # Setup
 /// - Create a mock server using the [`mockito`] crate to handle HTTP requests at mock endpoints
 /// - Create an [`EsiConfig`] with the `jwk_url` set to the mock server & reduced wait times
-/// - Create an EsiClient using the custom [`EsiConfig`]
+/// - Create an Client using the custom [`EsiConfig`]
 ///
 /// # Returns
 /// A tuple containing:
-/// - [`eve_esi::EsiClient`]: A basic EsiClient with jwk_url set to the mock server
+/// - [`eve_esi::Client`]: A basic Client with jwk_url set to the mock server
 /// - [`mockito::ServerGuard`]: A mock server for handling http requests for test purposes
-pub async fn setup() -> (EsiClient, ServerGuard) {
+pub async fn setup() -> (Client, ServerGuard) {
     // Setup mock server
     let mock_server = Server::new_async().await;
     let mock_server_url = mock_server.url();
@@ -37,14 +37,14 @@ pub async fn setup() -> (EsiClient, ServerGuard) {
         .expect("Failed to build EsiConfig");
 
     // Create ESI client with OAuth2 & the custom config
-    let esi_client = EsiClient::builder()
+    let esi_client = Client::builder()
         .user_agent("MyApp/1.0 (contact@example.com)")
         .client_id("client_id")
         .client_secret("client_secret")
         .callback_url("http://localhost:8000/callback")
         .config(config)
         .build()
-        .expect("Failed to build EsiClient");
+        .expect("Failed to build Client");
 
     (esi_client, mock_server)
 }

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -1,27 +1,25 @@
 use std::time::Duration;
 
-use eve_esi::config::EsiConfig;
-use eve_esi::Client;
 use mockito::{Server, ServerGuard};
 
 /// Utility function to create initial test setup for all jwk integration tests
 ///
 /// # Setup
 /// - Create a mock server using the [`mockito`] crate to handle HTTP requests at mock endpoints
-/// - Create an [`EsiConfig`] with the `jwk_url` set to the mock server & reduced wait times
-/// - Create an Client using the custom [`EsiConfig`]
+/// - Create an [`Config`] with the `jwk_url` set to the mock server & reduced wait times
+/// - Create an Client using the custom [`Config`]
 ///
 /// # Returns
 /// A tuple containing:
 /// - [`eve_esi::Client`]: A basic Client with jwk_url set to the mock server
 /// - [`mockito::ServerGuard`]: A mock server for handling http requests for test purposes
-pub async fn setup() -> (Client, ServerGuard) {
+pub async fn setup() -> (eve_esi::Client, ServerGuard) {
     // Setup mock server
     let mock_server = Server::new_async().await;
     let mock_server_url = mock_server.url();
 
     // Create a config with mock server JWK URL & reduced wait times
-    let config = EsiConfig::builder()
+    let config = eve_esi::Config::builder()
         // Set endpoints to mock server
         .esi_url(&mock_server_url)
         .token_url(&format!("{}/v2/oauth/token", mock_server.url()))
@@ -34,10 +32,10 @@ pub async fn setup() -> (Client, ServerGuard) {
         .jwk_cache_ttl(Duration::from_secs(2))
         .jwk_background_refresh_threshold(50) // 50% expiry for background refresh, 1 second
         .build()
-        .expect("Failed to build EsiConfig");
+        .expect("Failed to build Config");
 
     // Create ESI client with OAuth2 & the custom config
-    let esi_client = Client::builder()
+    let esi_client = eve_esi::Client::builder()
         .user_agent("MyApp/1.0 (contact@example.com)")
         .client_id("client_id")
         .client_secret("client_secret")


### PR DESCRIPTION
Renamed the following
- EsiClient -> Client
- EsiClientBuilder -> ClientBuilder
- EsiConfig -> Config
- EsiConfigBuilder -> ConfigBuilder
- EsiError -> Error
- EsiConfigError -> ConfigError

Additionally `lib.rs` exports have been updated to export the above if not already.