### PR TITLE
Wrap client in arc

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -145,7 +145,7 @@ impl ClientBuilder {
 
             // OAuth2
             oauth2_client: oauth_client,
-            jwt_key_cache: Arc::new(jwt_key_cache),
+            jwt_key_cache: jwt_key_cache,
         };
 
         // Wrap ClientRef in Client

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -47,6 +47,7 @@ use std::sync::Arc;
 
 use log::warn;
 
+use crate::client::ClientRef;
 use crate::config::Config;
 use crate::error::Error;
 use crate::oauth2::jwk::cache::JwtKeyCache;
@@ -137,14 +138,19 @@ impl ClientBuilder {
         // Setup JWT key cache
         let jwt_key_cache = JwtKeyCache::new(&config);
 
-        // Build Client
-        Ok(Client {
+        // Build ClientRef
+        let client_ref = ClientRef {
             reqwest_client,
             esi_url: config.esi_url,
 
             // OAuth2
             oauth2_client: oauth_client,
             jwt_key_cache: Arc::new(jwt_key_cache),
+        };
+
+        // Wrap ClientRef in Client
+        Ok(Client {
+            inner: Arc::new(client_ref),
         })
     }
 
@@ -405,8 +411,8 @@ mod tests {
         let client = result.unwrap();
 
         // Assert default ESI_URL is set and oauth client is none
-        assert_eq!(client.esi_url, DEFAULT_ESI_URL);
-        assert!(client.oauth2_client.is_none());
+        assert_eq!(client.inner.esi_url, DEFAULT_ESI_URL);
+        assert!(client.inner.oauth2_client.is_none());
     }
 
     /// Test successful build with OAuth configuration.
@@ -432,7 +438,7 @@ mod tests {
 
         // Assert oauth client was initialized
         let client = result.unwrap();
-        assert!(client.oauth2_client.is_some());
+        assert!(client.inner.oauth2_client.is_some());
     }
 
     /// Test build with a custom config overriding defaults
@@ -458,7 +464,7 @@ mod tests {
             .expect("Failed to build Client");
 
         // Assert default ESI URL has been overridden
-        assert_ne!(result.esi_url, DEFAULT_ESI_URL);
+        assert_ne!(result.inner.esi_url, DEFAULT_ESI_URL);
     }
 
     /// Test failed build due to partial OAuth configuration.

--- a/src/client.rs
+++ b/src/client.rs
@@ -66,7 +66,7 @@ pub(crate) struct ClientRef {
     pub(crate) oauth2_client: Option<OAuth2Client>,
     /// Cache containing JWT keys for validating OAuth2 tokens and fields for coordinating
     /// cache usage & refreshes across threads.
-    pub(crate) jwt_key_cache: Arc<JwtKeyCache>,
+    pub(crate) jwt_key_cache: JwtKeyCache,
 }
 
 impl Client {

--- a/src/client.rs
+++ b/src/client.rs
@@ -40,6 +40,7 @@ use crate::oauth2::jwk::cache::JwtKeyCache;
 /// an [`Arc`] internally for usage across multiple threads.
 ///
 /// For a full overview, features, and usage examples, see the [module-level documentation](self).
+#[derive(Clone)]
 pub struct Client {
     /// Inner reference containing the actual client implementation.
     pub(crate) inner: Arc<ClientRef>,

--- a/src/client.rs
+++ b/src/client.rs
@@ -13,6 +13,12 @@
 //! - [ESI API Documentation](https://developers.eveonline.com/api-explorer)
 //! - [EVE SSO Documentation](https://developers.eveonline.com/docs/services/sso/)
 //!
+//! ## Warning
+//! EVE ESI API requires setting a proper user agent. Failure to do so may result in rate limiting or API errors.
+//! Include application name, version, and contact information in your user agent string.
+//!
+//! Example: "MyApp/1.0 (contact@example.com)"
+//!
 //! ## Example
 //! ```
 //! // Set a user agent used to identify the application making ESI requests
@@ -21,12 +27,6 @@
 //!     .build()
 //!     .expect("Failed to build Client");
 //! ```
-//!
-//! ## Warning
-//! EVE ESI API requires setting a proper user agent. Failure to do so may result in rate limiting or API errors.
-//! Include application name, version, and contact information in your user agent string.
-//!
-//! Example: "MyApp/1.0 (contact@example.com)"
 
 use std::sync::Arc;
 
@@ -36,10 +36,21 @@ use crate::oauth2::jwk::cache::JwtKeyCache;
 
 /// The main client for interacting with EVE Online's ESI (EVE Stable Infrastructure) API.
 ///
-/// Use this struct to configure OAuth2 authentication and make requests to ESI endpoints.
+/// Use this struct to configure OAuth2 authentication and make requests to ESI endpoints. Uses
+/// an [`Arc`] internally for usage across multiple threads.
 ///
 /// For a full overview, features, and usage examples, see the [module-level documentation](self).
 pub struct Client {
+    /// Inner reference containing the actual client implementation.
+    pub(crate) inner: Arc<ClientRef>,
+}
+
+/// Reference type containing the actual client implementation.
+///
+/// This struct is wrapped in an [`Arc`] within the [`Client`] struct.
+///
+/// For a full overview, features, and usage examples, see the [module-level documentation](self).
+pub(crate) struct ClientRef {
     // Base settings
     /// HTTP client used to make requests to EVE Online's APIs
     pub(crate) reqwest_client: reqwest::Client,

--- a/src/endpoints/alliance.rs
+++ b/src/endpoints/alliance.rs
@@ -83,7 +83,7 @@ impl<'a> AllianceApi<'a> {
     /// }
     /// ```
     pub async fn get_alliance_information(&self, alliance_id: i32) -> Result<Alliance, Error> {
-        let url = format!("{}/alliances/{}/", self.client.esi_url, alliance_id);
+        let url = format!("{}/alliances/{}/", self.client.inner.esi_url, alliance_id);
 
         Ok(self.client.get_from_public_esi::<Alliance>(&url).await?)
     }

--- a/src/endpoints/character.rs
+++ b/src/endpoints/character.rs
@@ -90,7 +90,7 @@ impl<'a> CharacterApi<'a> {
         &self,
         character_id: i32,
     ) -> Result<Character, Error> {
-        let url = format!("{}/characters/{}/", self.client.esi_url, character_id);
+        let url = format!("{}/characters/{}/", self.client.inner.esi_url, character_id);
 
         Ok(self.client.get_from_public_esi::<Character>(&url).await?)
     }
@@ -136,7 +136,7 @@ impl<'a> CharacterApi<'a> {
         &self,
         character_ids: Vec<i32>,
     ) -> Result<Vec<CharacterAffiliation>, Error> {
-        let url = format!("{}/characters/affiliation/", self.client.esi_url);
+        let url = format!("{}/characters/affiliation/", self.client.inner.esi_url);
         let esi_client = self.client;
 
         Ok(esi_client

--- a/src/endpoints/corporation.rs
+++ b/src/endpoints/corporation.rs
@@ -88,7 +88,10 @@ impl<'a> CorporationApi<'a> {
         &self,
         corporation_id: i32,
     ) -> Result<Corporation, Error> {
-        let url = format!("{}/corporations/{}/", self.client.esi_url, corporation_id);
+        let url = format!(
+            "{}/corporations/{}/",
+            self.client.inner.esi_url, corporation_id
+        );
 
         Ok(self.client.get_from_public_esi::<Corporation>(&url).await?)
     }

--- a/src/esi.rs
+++ b/src/esi.rs
@@ -17,7 +17,7 @@ impl Client {
         &self,
         url: &str,
     ) -> Result<T, reqwest::Error> {
-        let req = self.reqwest_client.get(url).send().await?;
+        let req = self.inner.reqwest_client.get(url).send().await?;
         req.error_for_status_ref()?;
         let result: T = req.json().await?;
         Ok(result)
@@ -40,7 +40,13 @@ impl Client {
         url: &str,
         data: &U,
     ) -> Result<T, reqwest::Error> {
-        let req = self.reqwest_client.post(url).json(data).send().await?;
+        let req = self
+            .inner
+            .reqwest_client
+            .post(url)
+            .json(data)
+            .send()
+            .await?;
         req.error_for_status_ref()?;
         let result: T = req.json().await?;
         Ok(result)

--- a/src/esi.rs
+++ b/src/esi.rs
@@ -6,7 +6,7 @@ impl Client {
     /// Makes an unauthenticated GET request to the ESI API.
     ///
     /// # Arguments
-    /// - `url` - The ESI API endpoint URL to request.
+    /// - `url` ([`DeserializeOwned`]): The ESI API endpoint URL to request.
     ///
     /// # Returns
     /// A Result containing the deserialized response data or a reqwest error.
@@ -17,7 +17,9 @@ impl Client {
         &self,
         url: &str,
     ) -> Result<T, reqwest::Error> {
-        let req = self.inner.reqwest_client.get(url).send().await?;
+        let reqwest_client = &self.inner.reqwest_client;
+
+        let req = reqwest_client.get(url).send().await?;
         req.error_for_status_ref()?;
         let result: T = req.json().await?;
         Ok(result)
@@ -26,8 +28,8 @@ impl Client {
     /// Makes an unauthenticated POST request to the ESI API.
     ///
     /// # Arguments
-    /// - `url` - The ESI API endpoint URL to request.
-    /// - `data` - The data to send in the request body.
+    /// - `url` ([`DeserializeOwned`]):  The ESI API endpoint URL to request.
+    /// - `data` ([`Serialize`]): The data to send in the request body.
     ///
     /// # Returns
     /// A Result containing the deserialized response data or a reqwest error.
@@ -40,13 +42,9 @@ impl Client {
         url: &str,
         data: &U,
     ) -> Result<T, reqwest::Error> {
-        let req = self
-            .inner
-            .reqwest_client
-            .post(url)
-            .json(data)
-            .send()
-            .await?;
+        let reqwest_client = &self.inner.reqwest_client;
+
+        let req = reqwest_client.post(url).json(data).send().await?;
         req.error_for_status_ref()?;
         let result: T = req.json().await?;
         Ok(result)

--- a/src/oauth2/jwk/cache.rs
+++ b/src/oauth2/jwk/cache.rs
@@ -340,7 +340,7 @@ mod cache_get_keys_tests {
             .build()
             .expect("Failed to build Client");
 
-        let jwt_key_cache = esi_client.jwt_key_cache;
+        let jwt_key_cache = &esi_client.inner.jwt_key_cache;
 
         // Set JWT key cache
         {
@@ -376,7 +376,7 @@ mod cache_get_keys_tests {
             .build()
             .expect("Failed to build Client");
 
-        let jwt_key_cache = esi_client.jwt_key_cache;
+        let jwt_key_cache = &esi_client.inner.jwt_key_cache;
 
         // Do not set JWT key cache which is None by default
 
@@ -411,7 +411,7 @@ mod cache_update_keys_tests {
             .build()
             .expect("Failed to build Client");
 
-        let jwt_key_cache = esi_client.jwt_key_cache;
+        let jwt_key_cache = &esi_client.inner.jwt_key_cache;
 
         // Create mock keys
         let mock_keys = EveJwtKeys::create_mock_keys();
@@ -452,7 +452,7 @@ mod jwk_refresh_lock_try_acquire_tests {
             .expect("Failed to build Client");
 
         // Attempt to acquire lock
-        let jwt_key_cache = &esi_client.jwt_key_cache;
+        let jwt_key_cache = &esi_client.inner.jwt_key_cache;
 
         let lock_acquired = jwt_key_cache.refresh_lock_try_acquire();
 
@@ -483,7 +483,7 @@ mod jwk_refresh_lock_try_acquire_tests {
             .expect("Failed to build Client");
 
         // Acquire a lock initially
-        let jwt_key_cache = &esi_client.jwt_key_cache;
+        let jwt_key_cache = &esi_client.inner.jwt_key_cache;
 
         let lock = jwt_key_cache.refresh_lock_try_acquire();
 
@@ -493,7 +493,7 @@ mod jwk_refresh_lock_try_acquire_tests {
 
         // Acquire lock a second time
         // Should return false indicating lock is already in use
-        let jwt_key_cache = &esi_client.jwt_key_cache;
+        let jwt_key_cache = &esi_client.inner.jwt_key_cache;
 
         let lock_acquired = jwt_key_cache.refresh_lock_try_acquire();
 
@@ -534,7 +534,7 @@ mod jwk_lock_release_and_notify_tests {
             .expect("Failed to build Client");
 
         // Acquire a lock
-        let jwt_key_cache = &esi_client.jwt_key_cache;
+        let jwt_key_cache = &esi_client.inner.jwt_key_cache;
 
         let lock = !jwt_key_cache
             .refresh_lock
@@ -605,7 +605,7 @@ mod set_refresh_failure_tests {
             .build()
             .expect("Failed to build Client");
 
-        let jwt_key_cache = &esi_client.jwt_key_cache;
+        let jwt_key_cache = &esi_client.inner.jwt_key_cache;
 
         // Call function
         let timestamp = std::time::Instant::now();
@@ -636,7 +636,7 @@ mod set_refresh_failure_tests {
             .build()
             .expect("Failed to build Client");
 
-        let jwt_key_cache = &esi_client.jwt_key_cache;
+        let jwt_key_cache = &esi_client.inner.jwt_key_cache;
 
         // Set a refresh failure_timestamp
         {

--- a/src/oauth2/jwk/jwk.rs
+++ b/src/oauth2/jwk/jwk.rs
@@ -90,7 +90,7 @@ impl<'a> JwkApi<'a> {
     /// - [`EsiError`]: Returns an error if the JWT key cache is empty and new keys could not be fetched.
     pub async fn get_jwt_keys(&self) -> Result<EveJwtKeys, Error> {
         let esi_client = self.client;
-        let jwt_key_cache = &esi_client.jwt_key_cache;
+        let jwt_key_cache = &esi_client.inner.jwt_key_cache;
         let config = &jwt_key_cache.config;
 
         // Check if we have valid keys in the cache
@@ -165,7 +165,7 @@ impl<'a> JwkApi<'a> {
         // We have the lock, so refresh the cache
         // Attempt up to (2 retries) with an exponential (100 ms) backoff
         refresh_jwt_keys(
-            &esi_client.reqwest_client,
+            &esi_client.inner.reqwest_client,
             &jwt_key_cache,
             jwt_key_cache.config.refresh_max_retries,
         )
@@ -189,7 +189,11 @@ impl<'a> JwkApi<'a> {
     pub async fn fetch_and_update_cache(&self) -> Result<EveJwtKeys, Error> {
         let esi_client = self.client;
 
-        fetch_and_update_cache(&esi_client.reqwest_client, &esi_client.jwt_key_cache).await
+        fetch_and_update_cache(
+            &esi_client.inner.reqwest_client,
+            &esi_client.inner.jwt_key_cache,
+        )
+        .await
     }
 
     /// Fetches JWT keys from EVE's OAuth2 API
@@ -210,8 +214,8 @@ impl<'a> JwkApi<'a> {
         let esi_client = self.client;
 
         fetch_jwt_keys(
-            &esi_client.reqwest_client,
-            &esi_client.jwt_key_cache.config.jwk_url,
+            &esi_client.inner.reqwest_client,
+            &esi_client.inner.jwt_key_cache.config.jwk_url,
         )
         .await
     }

--- a/src/oauth2/jwk/util.rs
+++ b/src/oauth2/jwk/util.rs
@@ -213,7 +213,7 @@ mod is_refresh_cooldown_tests {
             .build()
             .expect("Failed to build Client");
 
-        let jwt_key_cache = esi_client.jwt_key_cache;
+        let jwt_key_cache = &esi_client.inner.jwt_key_cache;
 
         // Set the recent failure within cooldown period default of 60 seconds
         {
@@ -251,7 +251,7 @@ mod is_refresh_cooldown_tests {
             .build()
             .expect("Failed to build Client");
 
-        let jwt_key_cache = esi_client.jwt_key_cache;
+        let jwt_key_cache = &esi_client.inner.jwt_key_cache;
 
         // Set the last refresh failure greater than default of cooldown period of 60 seconds
         {
@@ -286,7 +286,7 @@ mod is_refresh_cooldown_tests {
             .build()
             .expect("Failed to build Client");
 
-        let jwt_key_cache = esi_client.jwt_key_cache;
+        let jwt_key_cache = &esi_client.inner.jwt_key_cache;
 
         // Run function
         let cooldown = check_refresh_cooldown(&jwt_key_cache).await;
@@ -327,7 +327,7 @@ mod is_cache_approaching_expiry_tests {
         let elapsed_seconds = timestamp.elapsed().as_secs();
 
         // Test function
-        let result = is_cache_approaching_expiry(&esi_client.jwt_key_cache, elapsed_seconds);
+        let result = is_cache_approaching_expiry(&esi_client.inner.jwt_key_cache, elapsed_seconds);
 
         // Assert true
         assert_eq!(result, true)
@@ -357,7 +357,7 @@ mod is_cache_approaching_expiry_tests {
         let elapsed_seconds = timestamp.elapsed().as_secs();
 
         // Test function
-        let result = is_cache_approaching_expiry(&esi_client.jwt_key_cache, elapsed_seconds);
+        let result = is_cache_approaching_expiry(&esi_client.inner.jwt_key_cache, elapsed_seconds);
 
         // Assert false
         assert_eq!(result, false)
@@ -393,7 +393,7 @@ mod is_cache_expired_tests {
         let elapsed_seconds = timestamp.elapsed().as_secs();
 
         // Test function
-        let result = is_cache_expired(&esi_client.jwt_key_cache, elapsed_seconds);
+        let result = is_cache_expired(&esi_client.inner.jwt_key_cache, elapsed_seconds);
 
         // Assert true
         assert_eq!(result, true)
@@ -423,7 +423,7 @@ mod is_cache_expired_tests {
         let elapsed_seconds = timestamp.elapsed().as_secs();
 
         // Test function
-        let result = is_cache_expired(&esi_client.jwt_key_cache, elapsed_seconds);
+        let result = is_cache_expired(&esi_client.inner.jwt_key_cache, elapsed_seconds);
 
         // Assert true
         assert_eq!(result, false)

--- a/src/oauth2/login.rs
+++ b/src/oauth2/login.rs
@@ -60,7 +60,7 @@ impl<'a> OAuth2Api<'a> {
     /// ```
     pub fn login_url(&self, scopes: Vec<String>) -> Result<AuthenticationData, Error> {
         // Retrieve the OAuth2 client from the Client
-        let client = match &self.client.oauth2_client {
+        let client = match &self.client.inner.oauth2_client {
             Some(client) => client,
             // Returns an error if the OAuth2 client is not found due to it not having been configured when
             // building the Client.

--- a/src/oauth2/token.rs
+++ b/src/oauth2/token.rs
@@ -48,14 +48,14 @@ impl<'a> OAuth2Api<'a> {
         &self,
         code: &str,
     ) -> Result<StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType>, Error> {
-        let client = match &self.client.oauth2_client {
+        let client = match &self.client.inner.oauth2_client {
             Some(client) => client,
             None => return Err(Error::OAuthError(OAuthError::OAuth2NotConfigured)),
         };
 
         match client
             .exchange_code(AuthorizationCode::new(code.to_string()))
-            .request_async(&self.client.reqwest_client)
+            .request_async(&self.client.inner.reqwest_client)
             .await
         {
             Ok(token) => Ok(token),


### PR DESCRIPTION
The primary Client has been changed to a struct with only the `inner` field containing an `Arc<ClientRef>` with the `ClientRef` being the struct which contains the actual fields used for the crate. This allows for better ease of use when it comes to using the eve_esi::Client across threads which is the primary intended use case for the client.

`JwtKeyCache` is no longer wrapped in an Arc as instead the `ClientRef` itself can be used in cases such as the proactive background JWT key cache refresh.