### PR TITLE
Add `get_token_refresh` Method

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -306,14 +306,14 @@ fn get_or_default_reqwest_client(
     client: Option<reqwest::Client>,
     user_agent: &Option<String>,
 ) -> Result<reqwest::Client, Error> {
-    match client {
-        Some(client) => {
-            if user_agent.is_some() {
-                warn!("user_agent is set on `ClientBuilder` but so is reqwest_client, as a result the user_agent will not be applied and should be instead applied to the provided reqwest client if not done so already.");
-            }
+    if user_agent.is_some() && client.is_some() {
+        let message = "user_agent is set on `ClientBuilder` but so is reqwest_client. The user_agent will not be applied and should be instead applied to the provided reqwest client if not done so already.";
 
-            Ok(client)
-        }
+        warn!("{}", message);
+    }
+
+    match client {
+        Some(client) => Ok(client),
         None => {
             let mut client_builder = reqwest::Client::builder();
             if let Some(agent) = user_agent {
@@ -474,7 +474,8 @@ mod tests {
     /// - Creates an ESI client builder with only the client_id set.
     ///
     /// # Assertions
-    /// - Verifies that the error response is ConfigError::MissingClientSecret
+    /// - Assert result is error
+    /// - Assert error is of type ConfigError::MissingClientSecret
     #[test]
     fn test_build_with_partial_oauth_config() {
         // Test that providing only client_id without the other OAuth params fails
@@ -483,11 +484,14 @@ mod tests {
             .client_id("client_id")
             .build();
 
+        // Assert result is error
         assert!(result.is_err());
-        match result {
-            Err(Error::ConfigError(ConfigError::MissingClientSecret)) => {}
-            _ => panic!("Expected MissingClientSecret error"),
-        }
+
+        // Assert error is of type ConfigError::MissingClientSecret
+        assert!(matches!(
+            result,
+            Err(Error::ConfigError(ConfigError::MissingClientSecret))
+        ));
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -574,44 +574,46 @@ mod tests {
     /// Tests the attempting initialize an Config with an invalid auth_url
     ///
     /// # Test Setup
-    /// - Attempt to build an Config with the auth_url set to an invalid URL.
+    /// - Create a Config with an invalid auth_url
     ///
     /// # Assertions
-    /// - Verifies that the error response is ConfigError::InvalidAuthUrl
+    /// - Assert result is an Error
+    /// - Assert error is of the ConfigError:InvalidAuthUrl variant
     #[test]
     fn test_invalid_auth_url() {
-        // Create an Config with an invalid auth_url
+        // Create a Config with an invalid auth_url
         let result = Config::builder().auth_url("invalid_url").build();
 
         // Assert result is an Error
         assert!(result.is_err());
 
-        match result {
-            // Assert error is of the ConfigError:InvalidAuthUrl variant
-            Err(Error::ConfigError(ConfigError::InvalidAuthUrl)) => {}
-            _ => panic!("Expected InvalidAuthUrl error"),
-        }
+        // Assert error is of the ConfigError:InvalidAuthUrl variant
+        assert!(matches!(
+            result,
+            Err(Error::ConfigError(ConfigError::InvalidAuthUrl))
+        ));
     }
 
     /// Tests the attempting initialize an Config with an invalid token_url
     ///
     /// # Test Setup
-    /// - Attempt to build an Config with the token_url set to an invalid URL.
+    /// - Create a Config with an invalid token_url
     ///
     /// # Assertions
-    /// - Verifies that the error response is ConfigError::InvalidTokenUrl
+    /// - Assert result is an Error
+    /// - Assert error is of the ConfigError:InvalidTokenUrl variant
     #[test]
     fn test_invalid_token_url() {
-        // Create an Config with an invalid token_url
+        // Create a Config with an invalid token_url
         let result = Config::builder().token_url("invalid_url").build();
 
         // Assert result is an Error
         assert!(result.is_err());
 
-        match result {
-            // Assert error is of the ConfigError:InvalidTokenUrl variant
-            Err(Error::ConfigError(ConfigError::InvalidTokenUrl)) => {}
-            _ => panic!("Expected InvalidTokenUrl error"),
-        }
+        // Assert error is of the ConfigError:InvalidTokenUrl variant
+        assert!(matches!(
+            result,
+            Err(Error::ConfigError(ConfigError::InvalidTokenUrl))
+        ));
     }
 }

--- a/src/endpoints/alliance.rs
+++ b/src/endpoints/alliance.rs
@@ -89,10 +89,12 @@ impl<'a> AllianceApi<'a> {
     pub async fn get_alliance_information(&self, alliance_id: i32) -> Result<Alliance, Error> {
         let url = format!("{}/alliances/{}/", self.client.inner.esi_url, alliance_id);
 
-        debug!(
+        let message = format!(
             "Fetching alliance information for alliance ID {} from {}",
             alliance_id, url
         );
+
+        debug!("{}", message);
 
         let start_time = Instant::now();
 
@@ -102,21 +104,25 @@ impl<'a> AllianceApi<'a> {
         let elapsed = start_time.elapsed();
         match result {
             Ok(alliance) => {
-                info!(
+                let message = format!(
                     "Successfully fetched alliance information for alliance ID: {} (took {}ms)",
                     alliance_id,
                     elapsed.as_millis()
                 );
 
+                info!("{}", message);
+
                 Ok(alliance)
             }
             Err(err) => {
-                error!(
+                let message = format!(
                     "Failed to fetch alliance information for alliance ID {} after {}ms due to error: {:#?}",
                     alliance_id,
                     elapsed.as_millis(),
                     err
                 );
+
+                error!("{}", message);
 
                 Err(err.into())
             }

--- a/src/endpoints/character.rs
+++ b/src/endpoints/character.rs
@@ -97,10 +97,12 @@ impl<'a> CharacterApi<'a> {
     ) -> Result<Character, Error> {
         let url = format!("{}/characters/{}/", self.client.inner.esi_url, character_id);
 
-        debug!(
+        let message = format!(
             "Fetching character information for character ID {} from {}",
             character_id, url
         );
+
+        debug!("{}", message);
 
         let start_time = Instant::now();
 
@@ -110,20 +112,25 @@ impl<'a> CharacterApi<'a> {
         let elapsed = start_time.elapsed();
         match result {
             Ok(character) => {
-                info!(
+                let message = format!(
                     "Successfully fetched character information for character ID: {} (took {}ms)",
                     character_id,
                     elapsed.as_millis()
                 );
 
+                info!("{}", message);
+
                 Ok(character)
             }
             Err(err) => {
-                error!("Failed to fetch character information for character ID {} after {}ms due to error: {:#?}",
-                    character_id,
-                    elapsed.as_millis(),
-                    err
+                let message = format!(
+                    "Failed to fetch character information for character ID {} after {}ms due to error: {:#?}",
+                        character_id,
+                        elapsed.as_millis(),
+                        err
                 );
+
+                error!("{}", message);
 
                 Err(err.into())
             }
@@ -173,11 +180,13 @@ impl<'a> CharacterApi<'a> {
     ) -> Result<Vec<CharacterAffiliation>, Error> {
         let url = format!("{}/characters/affiliation/", self.client.inner.esi_url);
 
-        debug!(
+        let message = format!(
             "Fetching character affiliations for {} characters from {}",
             character_ids.len(),
             url
         );
+
+        debug!("{}", message);
 
         let start_time = Instant::now();
 
@@ -190,21 +199,25 @@ impl<'a> CharacterApi<'a> {
         let elapsed = start_time.elapsed();
         match result {
             Ok(affiliations) => {
-                info!(
+                let message = format!(
                     "Successfully fetched character affiliations for {} character(s) (took {}ms)",
                     elapsed.as_millis(),
                     character_ids.len()
                 );
 
+                info!("{}", message);
+
                 Ok(affiliations)
             }
             Err(err) => {
-                error!(
+                let message = format!(
                     "Failed to fetch character affiliations for {} character(s) after {}ms due to error: {:#?}",
                     character_ids.len(),
                     elapsed.as_millis(),
                     err
                 );
+
+                error!("{}", message);
 
                 Err(err.into())
             }

--- a/src/endpoints/corporation.rs
+++ b/src/endpoints/corporation.rs
@@ -97,10 +97,12 @@ impl<'a> CorporationApi<'a> {
             self.client.inner.esi_url, corporation_id
         );
 
-        debug!(
+        let message = format!(
             "Fetching corporation information for corporation ID {} from {}",
             corporation_id, url
         );
+
+        debug!("{}", message);
 
         let start_time = Instant::now();
 
@@ -110,19 +112,24 @@ impl<'a> CorporationApi<'a> {
         let elapsed = start_time.elapsed();
         match result {
             Ok(corporation) => {
-                info!(
+                let message = format!(
                     "Successfully fetched corporation information for corporation ID: {} (took {}ms)",
                     corporation_id,
                     elapsed.as_millis()
                 );
 
+                info!("{}", message);
+
                 Ok(corporation)
             }
             Err(err) => {
-                error!(
-                    "Failed to fetch corporation information for corporation ID {} after {}ms due to error: {:#?}",
-                    corporation_id, elapsed.as_millis(), err
+                let message = format!(
+                    "Successfully fetched corporation information for corporation ID: {} (took {}ms)",
+                    corporation_id,
+                    elapsed.as_millis()
                 );
+
+                error!("{}", message);
 
                 Err(err.into())
             }

--- a/src/oauth2/client.rs
+++ b/src/oauth2/client.rs
@@ -117,94 +117,98 @@ mod tests {
         assert!(result.is_ok())
     }
 
-    /// Tests the attempting to initialize an Client for oauth2 with a missing client ID
+    /// Tests attempting to initialize an Client for oauth2 with a missing client ID
     ///
     /// # Test Setup
-    /// - Creates an ESI client with OAuth2 configured
+    /// - Create an ESI client without setting the client_id
     ///
     /// # Assertions
-    /// - Verifies that the error response is ConfigError::MissingClientId
+    /// - Assert result is error
+    /// - Assert error is of type ConfigError::MissingClientId
     #[test]
     fn test_missing_client_id() {
+        // Create an ESI client without setting the client_id
         let result = Client::builder()
             .user_agent("MyApp/1.0 (contact@example.com)")
             .client_secret("client_secret")
             .callback_url("http://localhost:8080/callback")
             .build();
 
-        match result {
-            Ok(_) => {
-                panic!("Expected Err");
-            }
-            Err(Error::ConfigError(ConfigError::MissingClientId)) => {
-                assert!(true);
-            }
-            Err(_) => panic!("Expected EsiError::MissingClientId"),
-        }
+        // Assert result is error
+        assert!(result.is_err());
+
+        // Assert error is of type ConfigError::MissingClientId
+        assert!(matches!(
+            result,
+            Err(Error::ConfigError(ConfigError::MissingClientId))
+        ));
     }
 
-    /// Tests the attempting to initialize an Client for oauth2 with a missing client secret
+    /// Tests attempting to initialize an Client for oauth2 with a missing client secret
     ///
     /// # Test Setup
     /// - Creates an ESI client with the client_secret not set.
     ///
     /// # Assertions
-    /// - Verifies that the error response is ConfigError::MissingClientSecret
+    /// - Assert result is error
+    /// - Assert error is of type ConfigError::MissingClientSecret
     #[test]
     fn test_missing_client_secret() {
+        // Create an ESI client without setting the client_secret
         let result = Client::builder()
             .user_agent("MyApp/1.0 (contact@example.com)")
             .client_id("client_id")
             .callback_url("http://localhost:8080/callback")
             .build();
 
-        match result {
-            Ok(_) => {
-                panic!("Expected Err");
-            }
-            Err(Error::ConfigError(ConfigError::MissingClientSecret)) => {
-                assert!(true);
-            }
-            Err(_) => panic!("Expected EsiError::MissingClientSecret"),
-        }
+        // Assert result is error
+        assert!(result.is_err());
+
+        // Assert error is of type ConfigError::MissingClientSecret
+        assert!(matches!(
+            result,
+            Err(Error::ConfigError(ConfigError::MissingClientSecret))
+        ));
     }
 
-    /// Tests the attempting initialize an Client for oauth2 with a missing callback_url
+    /// Tests attempting initialize an Client for oauth2 with a missing callback_url
     ///
     /// # Test Setup
-    /// - Creates an ESI client with the callback_url not set.
+    /// - Create an ESI client without setting the callback_url
     ///
     /// # Assertions
-    /// - Verifies that the error response is ConfigError::MissingCallbackUrl
+    /// - Assert result is error
+    /// - Assert error is of type ConfigError::MissingCallbackUrl
     #[test]
     fn test_missing_callback_url() {
-        // Create an ESI client
+        // Create an ESI client without setting the callback_url
         let result = Client::builder()
             .user_agent("MyApp/1.0 (contact@example.com)")
             .client_id("client_id")
             .client_secret("client_secret")
             .build();
 
-        match result {
-            Ok(_) => {
-                panic!("Expected Err");
-            }
-            Err(Error::ConfigError(ConfigError::MissingCallbackUrl)) => {
-                assert!(true);
-            }
-            Err(_) => panic!("Expected EsiError::MissingCallbackUrl"),
-        }
+        // Assert result is error
+        assert!(result.is_err());
+
+        // Assert error is of type ConfigError::MissingCallbackUrl
+        assert!(matches!(
+            result,
+            Err(Error::ConfigError(ConfigError::MissingCallbackUrl))
+        ));
     }
 
-    /// Tests the attempting initialize an Client for oauth2 with an invalid callback_url
+    /// Tests attempting initialize an Client for oauth2 with an invalid callback_url
     ///
     /// # Test Setup
-    /// - Creates an ESI client with the callback_url set to an invalid URL.
+    /// - Create an ESI client with an invalid callback_url
     ///
     /// # Assertions
-    /// - Verifies that the error response is ConfigError::InvalidCallbackUrl
+    /// - Assert result is error
+    /// - Assert error is of type ConfigError::InvalidCallbackUrl
     #[test]
     fn test_invalid_callback_url() {
+        // Create an ESI client with an invalid callback_url
         let result = Client::builder()
             .user_agent("MyApp/1.0 (contact@example.com)")
             .client_id("client_id")
@@ -212,10 +216,13 @@ mod tests {
             .callback_url("invalid_url") // Invalid URL
             .build();
 
+        // Assert result is error
         assert!(result.is_err());
-        match result {
-            Err(Error::ConfigError(ConfigError::InvalidCallbackUrl)) => {}
-            _ => panic!("Expected InvalidCallbackUrl error"),
-        }
+
+        // Assert error is of type ConfigError::InvalidCallbackUrl
+        assert!(matches!(
+            result,
+            Err(Error::ConfigError(ConfigError::InvalidCallbackUrl))
+        ));
     }
 }

--- a/src/oauth2/jwk/util.rs
+++ b/src/oauth2/jwk/util.rs
@@ -47,22 +47,26 @@ pub(super) async fn check_refresh_cooldown(jwt_key_cache: &JwtKeyCache) -> Optio
         let is_cooldown = elapsed_secs < config.refresh_cooldown.as_secs();
 
         if is_cooldown {
-            debug!(
+            let message = format!(
                 "Respecting background refresh cooldown: {}s elapsed of {}s required",
                 elapsed_secs,
                 config.refresh_cooldown.as_secs()
             );
+
+            debug!("{}", message);
 
             // Return Some with the remaining cooldown in seconds
             let remaining_cooldown = config.refresh_cooldown.as_secs() - elapsed_secs;
 
             return Some(remaining_cooldown);
         } else {
-            trace!(
+            let message = format!(
                 "Background cooldown period elapsed: {}s passed (required {}s)",
                 elapsed_secs,
                 config.refresh_cooldown.as_secs()
             );
+
+            trace!("{}", message);
 
             // Return None indicating there is no active cooldown
             return None;
@@ -109,7 +113,7 @@ pub(super) fn is_cache_approaching_expiry(jwt_key_cache: &JwtKeyCache, timestamp
     let threshold_seconds = (config.cache_ttl.as_secs() as f64 * threshold_percentage) as u64;
 
     if is_approaching_expiry {
-        debug!(
+        let message = format!(
             "JWT keys cache approaching expiry: elapsed={}s, threshold={}s ({}% of ttl={}s)",
             elapsed_seconds,
             threshold_seconds,
@@ -117,16 +121,20 @@ pub(super) fn is_cache_approaching_expiry(jwt_key_cache: &JwtKeyCache, timestamp
             config.cache_ttl.as_secs()
         );
 
+        debug!("{}", message);
+
         // Return true if cache is approaching expiry
         true
     } else {
-        trace!(
-                "JWT keys cache not yet approaching expiry: elapsed={}s, threshold={}s ({}% of ttl={}s)",
-                elapsed_seconds,
-                threshold_seconds,
-                config.background_refresh_threshold,
-                config.cache_ttl.as_secs()
-            );
+        let message = format!(
+            "JWT keys cache not yet approaching expiry: elapsed={}s, threshold={}s ({}% of ttl={}s)",
+            elapsed_seconds,
+            threshold_seconds,
+            config.background_refresh_threshold,
+            config.cache_ttl.as_secs()
+        );
+
+        trace!("{}", message);
 
         // Return false if cache is not yet approaching expiry
         false
@@ -152,20 +160,24 @@ pub(super) fn is_cache_expired(jwt_key_cache: &JwtKeyCache, timestamp: Instant) 
     let is_expired = timestamp.elapsed().as_millis() >= cache_ttl.as_millis();
 
     if is_expired {
-        debug!(
+        let message = format!(
             "JWT keys cache expired: elapsed={}s, ttl={}s",
             timestamp.elapsed().as_secs(),
             cache_ttl.as_secs()
         );
 
+        debug!("{}", message);
+
         // Return true if cache is not yet expired
         true
     } else {
-        trace!(
+        let message = format!(
             "JWT keys cache valid: elapsed={}s, ttl={}s",
             timestamp.elapsed().as_secs(),
             cache_ttl.as_secs()
         );
+
+        trace!("{}", message);
 
         // Return false if cache is still valid
         false

--- a/src/oauth2/login.rs
+++ b/src/oauth2/login.rs
@@ -5,6 +5,7 @@
 //!
 //! See the [module-level documentation](super) for an overview of EVE Online OAuth2 and usage example.
 
+use log::error;
 use oauth2::{CsrfToken, Scope};
 
 use crate::error::{Error, OAuthError};
@@ -64,7 +65,16 @@ impl<'a> OAuth2Api<'a> {
             Some(client) => client,
             // Returns an error if the OAuth2 client is not found due to it not having been configured when
             // building the Client.
-            None => return Err(Error::OAuthError(OAuthError::OAuth2NotConfigured)),
+            None => {
+                let message = format!(
+                    "Error building a login URL: {:#?}",
+                    OAuthError::OAuth2NotConfigured
+                );
+
+                error!("{}", message);
+
+                return Err(Error::OAuthError(OAuthError::OAuth2NotConfigured));
+            }
         };
 
         // Convert the Vec<String> of scopes into Vec<Scope>
@@ -146,9 +156,9 @@ mod tests {
         assert!(result.is_err());
 
         // Ensure error is of type EsiError::OAuthError(OAuthError::OAuth2NotConfigured)
-        match result {
-            Err(Error::OAuthError(OAuthError::OAuth2NotConfigured)) => {},
-            err => panic!("Expected EsiError::OAuthError(OAuthError::OAuth2NotConfigured), instead received: {:#?}", err),
-        }
+        assert!(matches!(
+            result,
+            Err(Error::OAuthError(OAuthError::OAuth2NotConfigured))
+        ));
     }
 }

--- a/src/oauth2/token.rs
+++ b/src/oauth2/token.rs
@@ -208,12 +208,12 @@ impl<'a> OAuth2Api<'a> {
             .await
         {
             Ok(token) => {
-                debug!("{}", "JWT Token fetched successfully");
+                debug!("{}", "JWT Token refreshed successfully");
 
                 Ok(token)
             }
             Err(err) => {
-                let message = format!("Error fetching refresh token: {:#?}", err);
+                let message = format!("Error refreshing JWT token token: {:#?}", err);
                 error!("{}", message);
 
                 Err(Error::OAuthError(OAuthError::RequestTokenError(err)))

--- a/tests/oauth2/token/mod.rs
+++ b/tests/oauth2/token/mod.rs
@@ -1,3 +1,4 @@
 mod get_token;
+mod get_token_refresh;
 mod util;
 mod validate_token;

--- a/tests/oauth2/token/mod.rs
+++ b/tests/oauth2/token/mod.rs
@@ -1,2 +1,3 @@
 mod get_token;
+mod util;
 mod validate_token;

--- a/tests/oauth2/token/util.rs
+++ b/tests/oauth2/token/util.rs
@@ -1,11 +1,10 @@
-use super::super::util::jwt::create_mock_token_keys;
+use super::super::util::jwt::create_mock_token;
 
 use mockito::{Mock, ServerGuard};
 
-/// Returns status code 200 with mock jwk keys
+/// Returns status code 200 with a mock token
 ///
-/// Adds a GET `/oauth/jwks` endpoint to the mock server which returns a set of mock
-/// JWK keys as expected from EVE Online's OAuth2 API.
+/// Adds a GET `/v2/oauth/token` endpoint to the mock server which returns a mock token.
 ///
 /// # Arguments
 /// - server (&mut [`mockito::ServerGuard`]): A mutable reference to a mock HTTP server which
@@ -15,14 +14,14 @@ use mockito::{Mock, ServerGuard};
 /// # Returns
 /// - [`mockito::Mock`]: A mock used with the `.assert()` method ensure expected requests
 ///   were received.
-pub(crate) fn get_jwk_success_response(server: &mut ServerGuard, expect: usize) -> Mock {
-    let mock_keys = create_mock_token_keys(false);
+pub(crate) fn get_token_success_response(server: &mut ServerGuard, expect: usize) -> Mock {
+    let mock_token = create_mock_token(false);
 
     let mock = server
-        .mock("GET", "/oauth/jwks")
+        .mock("POST", "/v2/oauth/token")
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(serde_json::to_string(&mock_keys).unwrap())
+        .with_body(serde_json::to_string(&mock_token).unwrap())
         .expect(expect)
         .create();
 
@@ -31,7 +30,7 @@ pub(crate) fn get_jwk_success_response(server: &mut ServerGuard, expect: usize) 
 
 /// Returns status code 500 internal server error
 ///
-/// Adds a GET `/oauth/jwks` endpoint to the mock server which returns a status code 500
+/// Adds a GET `/v2/oauth/token` endpoint to the mock server which returns a status code 500
 /// internal server error.
 ///
 /// # Arguments
@@ -42,15 +41,12 @@ pub(crate) fn get_jwk_success_response(server: &mut ServerGuard, expect: usize) 
 /// # Returns
 /// - [`mockito::Mock`]: A mock used with the `.assert()` method ensure expected requests
 ///   were received.
-pub(crate) fn get_jwk_internal_server_error_response(
-    server: &mut ServerGuard,
-    expect: usize,
-) -> Mock {
+pub(crate) fn get_token_bad_request_response(server: &mut ServerGuard, expect: usize) -> Mock {
     let mock = server
-        .mock("GET", "/oauth/jwks")
-        .with_status(500)
+        .mock("POST", "/v2/oauth/token")
+        .with_status(400)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"error": "Internal Server Error"}"#)
+        .with_body(r#"{"error": "Bad request"}"#)
         .expect(expect)
         .create();
 

--- a/tests/oauth2/util/jwt.rs
+++ b/tests/oauth2/util/jwt.rs
@@ -121,6 +121,9 @@ pub fn create_mock_token(
     let access_token = AccessToken::new(access_token_secret);
     let token_type = BasicTokenType::Bearer;
     let expires_in = Some(&Duration::from_secs(3600)); // 1 hour
+
+    // We aren't actually validating this refresh token in get_token_refresh tests,
+    // we just use this for the get_token_refresh argument to test the execution paths.
     let refresh_token = Some(RefreshToken::new("mock_refresh_token_value".to_string()));
 
     // Create empty extra fields


### PR DESCRIPTION
# Features
- `get_token_refresh`: method to fetch a new JWT token from EVE Online's Oauth2 API using a refresh token. 

# Refactors
- Large amount of refactors regarding the usage of the `log` crate macros due to cargo-llvm-cov issues with reading coverage. Issue has been documented in CONTRIBUTING.md
- Additional some refactors have been done replacing the usage of `match` statements with the `matches!` macro instead in unit tests as those were another source of code coverage issues.
- The `get_token.rs` integration tests have been refactored with better assertions, documentation, and reduced repetition.

# Integration Tests
Integrations tests have been added for the `get_token_refresh` method that are largely just a copy of the `get_token` method's integration paths due to execution paths being identical but differing slightly in the usage of a refresh token rather than authorization code.
- Integration test for successfully refreshing a token
- Integration test for when the API returns a bad request
- Integration test for when OAuth2 is not configure on the ESI Client.