### PR TITLE
Add alliance ESI routes

### DIFF
--- a/src/endpoints/alliance.rs
+++ b/src/endpoints/alliance.rs
@@ -57,7 +57,7 @@ impl<'a> AllianceApi<'a> {
     /// Retrieves a list of IDs of every alliance in EVE Online
     ///
     /// # EVE ESI Reference
-    /// - <https://developers.eveonline.com/api-explorer#/operations/GetAlliances)>
+    /// - <https://developers.eveonline.com/api-explorer#/operations/GetAlliances>
     ///
     /// # Returns
     /// A result containing either:
@@ -145,6 +145,62 @@ impl<'a> AllianceApi<'a> {
             Err(err) => {
                 let message = format!(
                     "Failed to fetch alliance information for alliance ID {} after {}ms due to error: {:#?}",
+                    alliance_id,
+                    elapsed.as_millis(),
+                    err
+                );
+
+                error!("{}", message);
+
+                Err(err.into())
+            }
+        }
+    }
+
+    /// Retrieves the IDs of all corporations part of the provided alliance_id
+    ///
+    /// # EVE ESI Reference
+    /// - <https://developers.eveonline.com/api-explorer#/operations/GetAlliancesAllianceIdCorporations>
+    ///
+    /// # Returns
+    /// A result containing either:
+    /// - `Vec<`[`i32`]`>`: A vec of the ID of every corporation part of the alliance
+    /// - [`Error`]: An error if the fetch request failed
+    pub async fn list_alliance_corporations(&self, alliance_id: i32) -> Result<Vec<i32>, Error> {
+        let url = format!(
+            "{}/alliances/{}/corporations",
+            self.client.inner.esi_url, alliance_id
+        );
+
+        let message = format!(
+            "Fetching IDs of all corporations part of alliance {} from {}",
+            alliance_id, url
+        );
+
+        debug!("{}", message);
+
+        let start_time = Instant::now();
+
+        // Fetch all alliances
+        let result = self.client.get_from_public_esi::<Vec<i32>>(&url).await;
+
+        let elapsed = start_time.elapsed();
+        match result {
+            Ok(corporations) => {
+                let message = format!(
+                    "Successfully fetched IDs for {} corporation(s) part of alliance {} (took {}ms)",
+                    corporations.len(),
+                    alliance_id,
+                    elapsed.as_millis()
+                );
+
+                info!("{}", message);
+
+                Ok(corporations)
+            }
+            Err(err) => {
+                let message = format!(
+                    "Failed to fetch IDs of all corporations part of alliance {} after {}ms due to error: {:#?}",
                     alliance_id,
                     elapsed.as_millis(),
                     err

--- a/src/model/alliance.rs
+++ b/src/model/alliance.rs
@@ -2,27 +2,15 @@
 //!
 //! This module defines the `Alliance` struct, which models the core properties of an alliance in EVE Online.
 //!
-//! See [ESI API documentation](https://developers.eveonline.com/api-explorer#/schemas/AlliancesAllianceIdGet)
+//! See [ESI API documentation](https://developers.eveonline.com/api-explorer)
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 /// Represents an alliance in EVE Online.
 ///
-/// Alliances are player-run organizations made up of multiple corporations.
-/// This struct contains the basic information about an alliance as returned by the EVE ESI API.
-///
 /// # Documentation
-/// See [ESI API documentation](https://developers.eveonline.com/api-explorer#/schemas/AlliancesAllianceIdGet)
-/// for the details related to the alliance Schema defined by ESI.
-///
-/// # Fields
-/// The struct contains identifying information about the alliance, including:
-/// - IDs for the alliance's creator (both character and corporation)
-/// - The founding date of the alliance
-/// - The ID of the alliance's executor corporation if the alliance is not disbanded.
-/// - The ID of the alliance's faction if applicable.
-/// - Basic identifying information such as name and ticker
+/// - <https://developers.eveonline.com/api-explorer#/schemas/AlliancesAllianceIdGet>
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 pub struct Alliance {
     /// The ID of the corporation that created the alliance.
@@ -40,4 +28,16 @@ pub struct Alliance {
     pub name: String,
     /// The ticker of the alliance.
     pub ticker: String,
+}
+
+/// Reoresents the 128x128 & 64x64 icon URLs for an alliance
+///
+/// # Documentation
+/// - <https://developers.eveonline.com/api-explorer#/schemas/AlliancesAllianceIdIconsGet>
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct AllianceIcons {
+    /// 128x128 icon URL for an alliance
+    pub px128x128: String,
+    /// 64x64 icon URL for an alliance
+    pub px64x64: String,
 }

--- a/tests/endpoints/alliance/get_alliance_icon.rs
+++ b/tests/endpoints/alliance/get_alliance_icon.rs
@@ -1,36 +1,38 @@
+use eve_esi::model::alliance::AllianceIcons;
+
 use crate::util::setup;
 
-/// Successful retrieval of IDs of corporations part of an alliance
+/// Successful retrieval of alliance icons
 ///
 /// # Test Setup
 /// - Setup a basic EsiClient & mock HTTP server
-/// - Create mock Vec of corporation IDs
-/// - Configure mock server with an ESI endpoint returning a mock list of corporation IDs
+/// - Create mock alliance icons
+/// - Configure mock server with endpoint returning mock alliance icons
 ///
 /// # Assertions
 /// - Assert 1 request was made to the mock server
 /// - Assert result is Ok
 #[tokio::test]
-async fn test_list_alliance_corporations_success() {
+async fn test_get_alliance_icon_success() {
     // Setup a basic EsiClient & mock HTTP server
     let (esi_client, mut mock_server) = setup().await;
 
-    // Create mock Vec of corporation IDs
-    let mock_corporation_ids = vec![1, 2, 3, 4, 5, 6, 7, 8, 9];
+    // Create mock alliance icons
+    let mock_icons = AllianceIcons {
+        px128x128: "ABCD".to_string(),
+        px64x64: "ABCD".to_string(),
+    };
 
-    // Configure mock server with an ESI endpoint returning a mock list of corporation IDs
+    // Configure mock server with endpoint returning mock alliance icons
     let mock = mock_server
-        .mock("GET", "/alliances/99013534/corporations")
+        .mock("GET", "/alliances/99013534/icons")
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(serde_json::to_string(&mock_corporation_ids).unwrap())
+        .with_body(serde_json::to_string(&mock_icons).unwrap())
         .create();
 
     // Retrieve the list of corporations part of alliance 99013534
-    let result = esi_client
-        .alliance()
-        .list_alliance_corporations(99013534)
-        .await;
+    let result = esi_client.alliance().get_alliance_icon(99013534).await;
 
     // Assert 1 request was made to the mock server
     mock.assert();
@@ -39,7 +41,7 @@ async fn test_list_alliance_corporations_success() {
     assert!(result.is_ok());
 }
 
-/// Receiving an error 404 when calling list_alliance_corporations()
+/// Receiving an error 404 when attempting to retrieve alliance icons
 ///
 /// # Test Setup
 /// - Setup a basic EsiClient & mock HTTP server
@@ -50,23 +52,20 @@ async fn test_list_alliance_corporations_success() {
 /// - Assert result is error
 /// - Assert error is due to not found error
 #[tokio::test]
-async fn test_list_alliance_corporations_not_found() {
+async fn test_get_alliance_icon_not_found() {
     // Setup a basic EsiClient & mock HTTP server
     let (esi_client, mut mock_server) = setup().await;
 
     // Configure a mock response returning a 404 not found
     let mock = mock_server
-        .mock("GET", "/alliances/99013534/corporations")
+        .mock("GET", "/alliances/99013534/icons")
         .with_status(404)
         .with_header("content-type", "application/json")
         .with_body(r#"{"error": "Alliance not found"}"#)
         .create();
 
     // Retrieve the list of corporations part of alliance 99013534
-    let result = esi_client
-        .alliance()
-        .list_alliance_corporations(99013534)
-        .await;
+    let result = esi_client.alliance().get_alliance_icon(99013534).await;
 
     // Assert 1 request was made to the mock server
     mock.assert();

--- a/tests/endpoints/alliance/get_alliance_information.rs
+++ b/tests/endpoints/alliance/get_alliance_information.rs
@@ -29,7 +29,7 @@ async fn get_alliance_information() {
         ticker: "AUTMN".to_string(),
     };
 
-    // Configure mock server with an ESI endpoint returning 404 not found
+    // Configure mock server with an ESI endpoint returning the mock alliance
     let mock = mock_server
         .mock("GET", "/alliances/99013534/")
         .with_status(200)
@@ -63,7 +63,7 @@ async fn get_alliance_information() {
 /// # Assertions
 /// - Assert 1 request was made to the mock server
 /// - Assert result is error
-/// - Assert reqwest error is due to status NOT_FOUND
+/// - Assert error is due to internal server error
 #[tokio::test]
 async fn get_alliance_information_not_found() {
     // Setup a basic EsiClient & mock HTTP server
@@ -88,17 +88,9 @@ async fn get_alliance_information_not_found() {
 
     // Assert result is error
     assert!(result.is_err());
-    match result {
-        Err(eve_esi::Error::ReqwestError(err)) => {
-            // Assert reqwest error is due to status NOT_FOUND
-            assert!(err.status().is_some());
-            assert_eq!(err.status().unwrap(), reqwest::StatusCode::NOT_FOUND);
-        }
-        err => {
-            panic!(
-                "Expected ReqwestError, got different error type: {:#?}",
-                err
-            )
-        }
-    }
+
+    // Assert error is due to internal server error
+    assert!(
+        matches!(result, Err(eve_esi::Error::ReqwestError(ref e)) if e.status() == Some(reqwest::StatusCode::NOT_FOUND))
+    );
 }

--- a/tests/endpoints/alliance/list_all_alliances.rs
+++ b/tests/endpoints/alliance/list_all_alliances.rs
@@ -10,7 +10,6 @@ use crate::util::setup;
 /// # Assertions
 /// - Assert 1 request was made to the mock server
 /// - Assert result is Ok
-/// - Assert received expected alliance data
 #[tokio::test]
 async fn test_list_all_alliances_success() {
     // Setup a basic EsiClient & mock HTTP server

--- a/tests/endpoints/alliance/list_all_alliances.rs
+++ b/tests/endpoints/alliance/list_all_alliances.rs
@@ -5,7 +5,7 @@ use crate::util::setup;
 /// # Test Setup
 /// - Setup a basic EsiClient & mock HTTP server
 /// - Create mock Vec of alliance IDs
-/// - Configure mock server with an ESI endpoint a mock list of alliance IDs
+/// - Configure mock server with endpoint returning mock alliance IDs
 ///
 /// # Assertions
 /// - Assert 1 request was made to the mock server
@@ -16,14 +16,14 @@ async fn test_list_all_alliances_success() {
     let (esi_client, mut mock_server) = setup().await;
 
     // Create mock Vec of alliance IDs
-    let mock_alliance = vec![1, 2, 3, 4, 5, 6, 7, 8, 9];
+    let mock_alliance_ids = vec![1, 2, 3, 4, 5, 6, 7, 8, 9];
 
-    // Configure mock server with an ESI endpoint a mock list of alliance IDs
+    // Configure mock server with endpoint returning mock alliance IDs
     let mock = mock_server
         .mock("GET", "/alliances")
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(serde_json::to_string(&mock_alliance).unwrap())
+        .with_body(serde_json::to_string(&mock_alliance_ids).unwrap())
         .create();
 
     // Retrieve the list of alliances

--- a/tests/endpoints/alliance/list_all_alliances.rs
+++ b/tests/endpoints/alliance/list_all_alliances.rs
@@ -1,0 +1,76 @@
+use crate::util::setup;
+
+/// Successful retrieval of list of alliance IDs
+///
+/// # Test Setup
+/// - Setup a basic EsiClient & mock HTTP server
+/// - Create mock Vec of alliance IDs
+/// - Configure mock server with an ESI endpoint a mock list of alliance IDs
+///
+/// # Assertions
+/// - Assert 1 request was made to the mock server
+/// - Assert result is Ok
+/// - Assert received expected alliance data
+#[tokio::test]
+async fn test_list_all_alliances_success() {
+    // Setup a basic EsiClient & mock HTTP server
+    let (esi_client, mut mock_server) = setup().await;
+
+    // Create mock Vec of alliance IDs
+    let mock_alliance = vec![1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+    // Configure mock server with an ESI endpoint a mock list of alliance IDs
+    let mock = mock_server
+        .mock("GET", "/alliances")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(serde_json::to_string(&mock_alliance).unwrap())
+        .create();
+
+    // Retrieve the list of alliances
+    let result = esi_client.alliance().list_all_alliances().await;
+
+    // Assert 1 request was made to the mock server
+    mock.assert();
+
+    // Assert result is Ok
+    assert!(result.is_ok());
+}
+
+/// Receiving an error 500 when calling list_all_alliances()
+///
+/// # Test Setup
+/// - Setup a basic EsiClient & mock HTTP server
+/// - Configure mock server with an ESI endpoint returning a 600 internal server error
+///
+/// # Assertions
+/// - Assert 1 request was made to the mock server
+/// - Assert result is error
+/// - Assert error is due to internal server error
+#[tokio::test]
+async fn test_list_all_alliances_internal_error() {
+    // Setup a basic EsiClient & mock HTTP server
+    let (esi_client, mut mock_server) = setup().await;
+
+    // Configure a mock response returning a 500 internal server error
+    let mock = mock_server
+        .mock("GET", "/alliances")
+        .with_status(500)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"error": "Internal server error"}"#)
+        .create();
+
+    // Retrieve the list of alliances
+    let result = esi_client.alliance().list_all_alliances().await;
+
+    // Assert 1 request was made to the mock server
+    mock.assert();
+
+    // Assert result is error
+    assert!(result.is_err());
+
+    // Assert error is due to internal server error
+    assert!(
+        matches!(result, Err(eve_esi::Error::ReqwestError(ref e)) if e.status() == Some(reqwest::StatusCode::INTERNAL_SERVER_ERROR))
+    );
+}

--- a/tests/endpoints/alliance/list_alliance_corporations.rs
+++ b/tests/endpoints/alliance/list_alliance_corporations.rs
@@ -1,0 +1,81 @@
+use crate::util::setup;
+
+/// Successful retrieval of IDs of corporations part of an alliance
+///
+/// # Test Setup
+/// - Setup a basic EsiClient & mock HTTP server
+/// - Create mock Vec of corporation IDs
+/// - Configure mock server with an ESI endpoint a mock list of corporation IDs
+///
+/// # Assertions
+/// - Assert 1 request was made to the mock server
+/// - Assert result is Ok
+#[tokio::test]
+async fn test_list_alliance_corporations_success() {
+    // Setup a basic EsiClient & mock HTTP server
+    let (esi_client, mut mock_server) = setup().await;
+
+    // Create mock Vec of corporation IDs
+    let mock_alliance = vec![1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+    // Configure mock server with an ESI endpoint a mock list of corporation IDs
+    let mock = mock_server
+        .mock("GET", "/alliances/99013534/corporations")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(serde_json::to_string(&mock_alliance).unwrap())
+        .create();
+
+    // Retrieve the list of corporations part of alliance 99013534
+    let result = esi_client
+        .alliance()
+        .list_alliance_corporations(99013534)
+        .await;
+
+    // Assert 1 request was made to the mock server
+    mock.assert();
+
+    // Assert result is Ok
+    assert!(result.is_ok());
+}
+
+/// Receiving an error 404 when calling list_alliance_corporations()
+///
+/// # Test Setup
+/// - Setup a basic EsiClient & mock HTTP server
+/// - Configure a mock response returning a 404 not found
+///
+/// # Assertions
+/// - Assert 1 request was made to the mock server
+/// - Assert result is error
+/// - Assert error is due to not found error
+#[tokio::test]
+async fn test_list_alliance_corporations_not_found() {
+    // Setup a basic EsiClient & mock HTTP server
+    let (esi_client, mut mock_server) = setup().await;
+
+    // Configure a mock response returning a 404 not found
+    let mock = mock_server
+        .mock("GET", "/alliances/99013534/corporations")
+        .with_status(404)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"error": "Alliance not found"}"#)
+        .create();
+
+    // Retrieve the list of corporations part of alliance 99013534
+    let result = esi_client
+        .alliance()
+        .list_alliance_corporations(99013534)
+        .await;
+
+    // Assert 1 request was made to the mock server
+    mock.assert();
+
+    // Assert result is error
+    assert!(result.is_err());
+
+    // Assert error is due to not found error
+    assert!(
+        matches!(result, Err(eve_esi::Error::ReqwestError(ref e)) if e.status() == Some(reqwest::StatusCode::NOT_FOUND))
+    );
+}

--- a/tests/endpoints/alliance/mod.rs
+++ b/tests/endpoints/alliance/mod.rs
@@ -1,3 +1,4 @@
+mod get_alliance_icon;
 mod get_alliance_information;
 mod list_all_alliances;
 mod list_alliance_corporations;

--- a/tests/endpoints/alliance/mod.rs
+++ b/tests/endpoints/alliance/mod.rs
@@ -1,2 +1,3 @@
 mod get_alliance_information;
 mod list_all_alliances;
+mod list_alliance_corporations;

--- a/tests/endpoints/alliance/mod.rs
+++ b/tests/endpoints/alliance/mod.rs
@@ -1,1 +1,2 @@
 mod get_alliance_information;
+mod list_all_alliances;


### PR DESCRIPTION
All alliance ESI routes complete

# New Methods
- `list_all_alliances`: Retrieves a list of IDs of every alliance in EVE Online
- `get_alliance_information`: Retrieves public information for the given alliance_id
- list_alliance_corporations`: Retrieves the IDs of all corporations part of the provided alliance_id
- `get_alliance_icon`: Get the 128x128 & 64x64 icon URLs for an alliance

# New Structs
- `AllianceIcons`: Represents the 128x128 & 64x64 icon URLs for an alliance