### PR TITLE
Use chrono for EveJwtClaims timestamps

### DIFF
--- a/src/esi/util.rs
+++ b/src/esi/util.rs
@@ -83,7 +83,9 @@ pub(super) fn check_token_scopes(
 
 #[cfg(test)]
 mod check_token_expiration_tests {
-    use std::time::{SystemTime, UNIX_EPOCH};
+    use std::time::Duration;
+
+    use chrono::Utc;
 
     use super::check_token_expiration;
     use crate::{model::oauth2::EveJwtClaims, Error, OAuthError};
@@ -101,14 +103,9 @@ mod check_token_expiration_tests {
     /// Error occurs due to token being expired
     #[test]
     fn test_check_token_expiration_error() {
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs() as i64;
-
         let mut mock_claims = EveJwtClaims::mock();
-        mock_claims.exp = now - 60; // expired 1 minute ago
-        mock_claims.iat = now - 960; // created 16 minutes ago
+        mock_claims.exp = Utc::now() - Duration::from_secs(60); // expired 1 minute ago
+        mock_claims.iat = Utc::now() - Duration::from_secs(960); // created 16 minutes ago
 
         let result = check_token_expiration(&mock_claims);
 

--- a/src/model/oauth2/jwt_claims.rs
+++ b/src/model/oauth2/jwt_claims.rs
@@ -123,7 +123,6 @@ impl EveJwtClaims {
         let token_expiration = self.exp;
 
         if now < token_expiration {
-            // Token is not yet expired
             let time_remaining = self.exp - now;
             let message = format!(
                 "Checked token for expiration, token for character ID {} is not yet expired, expiration in {}s",
@@ -135,10 +134,11 @@ impl EveJwtClaims {
             return false;
         }
 
-        // Token is expired
+        let time_remaining = now - self.exp;
         let message = format!(
-            "Checked token for expiration, token for character ID {} is expired",
-            character_id
+            "Checked token for expiration, token for character ID {} is expired, expired {}s ago",
+            character_id,
+            time_remaining.num_seconds()
         );
         log::debug!("{}", message);
 

--- a/src/model/oauth2/jwt_claims.rs
+++ b/src/model/oauth2/jwt_claims.rs
@@ -15,8 +15,7 @@
 //!
 /// ## EVE Online OAuth2 Documentation
 /// - <https://developers.eveonline.com/docs/services/sso/#validating-jwt-tokens>
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
-
+use chrono::{DateTime, Duration, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::{Error, OAuthError};
@@ -46,10 +45,12 @@ pub struct EveJwtClaims {
     pub tenant: String,
     /// The region from which the token was issued (world)
     pub region: String,
-    /// Expiration time (Unix timestamp)
-    pub exp: i64,
-    /// Issued at time (Unix timestamp)
-    pub iat: i64,
+    /// Expiration time
+    #[serde(with = "jwt_timestamp_format")]
+    pub exp: DateTime<Utc>,
+    /// Issued at time
+    #[serde(with = "jwt_timestamp_format")]
+    pub iat: DateTime<Utc>,
     // This field behaves oddly when deserializing due to:
     // - 0 scopes requested: `scp` field won't exist on claims body
     // - 1 scope requested: Field exists as String
@@ -116,26 +117,18 @@ impl EveJwtClaims {
     /// # Returns
     /// - `bool`: Indicating whether or not token is expired
     pub fn is_expired(&self) -> bool {
-        // Set character_id for logging to 0 if `sub` field can't be parsed to id
         let character_id = self.character_id().unwrap_or(0);
 
-        // Trace because validate_token already logs info for this
-        let message = format!(
-            "Successfully validated token for character ID {} prior to token expiration check",
-            character_id
-        );
-        log::trace!("{}", message);
+        let now = Utc::now();
+        let token_expiration = self.exp;
 
-        // Check token expiration
-        let expiration_secs = Duration::from_secs(self.exp as u64);
-        let expiration = UNIX_EPOCH + expiration_secs;
-
-        if SystemTime::now() < expiration {
+        if now < token_expiration {
             // Token is not yet expired
+            let time_remaining = self.exp - now;
             let message = format!(
                 "Checked token for expiration, token for character ID {} is not yet expired, expiration in {}s",
                 character_id,
-                expiration_secs.as_secs()
+                time_remaining.num_seconds()
             );
             log::debug!("{}", message);
 
@@ -196,12 +189,6 @@ impl EveJwtClaims {
 
     /// Utility function to create a mock of EveJwtClaims
     pub fn mock() -> Self {
-        // Get current unix timestamp
-        let unix_timstamp_now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs() as i64;
-
         // Create JWT mock claims matching what EVE Online would return
         EveJwtClaims {
             // ESI SSO docs defines 2 different JWT issuers but typically only returns 1 of them at a time
@@ -213,8 +200,8 @@ impl EveJwtClaims {
             kid: "JWT-Signature-Key-1".to_string(),
             tenant: "tranquility".to_string(),
             region: "world".to_string(),
-            exp: unix_timstamp_now + 900, // Valid for 15 minutes
-            iat: unix_timstamp_now,
+            exp: Utc::now() + Duration::seconds(900), // Valid for 15 minutes
+            iat: Utc::now(),
             scp: vec![
                 "publicData".to_string(),
                 "esi-characters.read_agents_research.v1".to_string(),
@@ -272,6 +259,32 @@ where
     }
 }
 
+/// Deserializes i64 unix timestamp common for JWTs into DateTime<Utc>
+mod jwt_timestamp_format {
+    use chrono::{DateTime, TimeZone, Utc};
+    use serde::{self, Deserialize, Deserializer, Serializer};
+
+    /// Converts DateTime<Utc> into an i64 unix timestamp for serializing token claims primarily used in tests
+    pub fn serialize<S>(date: &DateTime<Utc>, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_i64(date.timestamp())
+    }
+
+    /// Converts i64 unix timestamp into a DateTime<Utc> for the EveJwtClaims struct
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<DateTime<Utc>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let timestamp = i64::deserialize(deserializer)?;
+        Ok(Utc
+            .timestamp_opt(timestamp, 0)
+            .single()
+            .ok_or_else(|| serde::de::Error::custom("Invalid timestamp"))?)
+    }
+}
+
 #[cfg(test)]
 mod claims_character_id_tests {
     use crate::{model::oauth2::EveJwtClaims, Error, OAuthError};
@@ -325,7 +338,8 @@ mod claims_character_id_tests {
 
 #[cfg(test)]
 mod is_expired_tests {
-    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use chrono::{Duration, Utc};
 
     use crate::model::oauth2::EveJwtClaims;
 
@@ -342,14 +356,9 @@ mod is_expired_tests {
     /// Ensures that when token is expired, function returns true
     #[tokio::test]
     async fn test_is_expired_true() {
-        let now = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs() as i64;
-
         let mut mock_claims = EveJwtClaims::mock();
-        mock_claims.exp = now - 60; // Expired 1 minute ago
-        mock_claims.iat = now - 960; // Created 16 minutes ago
+        mock_claims.exp = Utc::now() - Duration::seconds(60); // Expired 1 minute ago
+        mock_claims.iat = Utc::now() - Duration::seconds(960); // Created 16 minutes ago
 
         let result = mock_claims.is_expired();
 
@@ -522,6 +531,60 @@ mod deserialize_scp_tests {
 
         assert!(matches!(result,
             Err(err) if err.to_string().contains("Expected string array for scopes")
+        ));
+    }
+}
+
+#[cfg(test)]
+mod test_jwt_timestamp_format {
+    use super::EveJwtClaims;
+
+    use chrono::{Duration, Utc};
+
+    /// Helper function to create JSON test data with a customizable exp field
+    fn create_test_jwt_json(exp_value: impl Into<serde_json::Value>) -> serde_json::Value {
+        let iat = Utc::now();
+
+        serde_json::json!({
+            "iss": "https://login.eveonline.com",
+            "sub": "CHARACTER:EVE:123456789",
+            "aud": ["client_id".to_string(), "EVE Online"],
+            "jti": "abc123def456",
+            "kid": "JWT-Signature-Key-1",
+            "tenant": "tranquility",
+            "region": "world",
+            "exp": exp_value.into(),
+            "iat": iat.timestamp(),
+            "scp": [],
+            "name": "Test Character",
+            "owner": "123456789",
+            "azp": "client_id"
+        })
+    }
+
+    /// Error due to invalid i64 unix timestamp
+    #[test]
+    fn test_jwt_timestamp_format_success() {
+        // Valid for 15 minutes
+        let exp = Utc::now() + Duration::seconds(900);
+
+        let json_data = create_test_jwt_json(exp.timestamp());
+        let result = serde_json::from_value::<EveJwtClaims>(json_data);
+
+        assert!(result.is_ok());
+    }
+
+    /// Error due to invalid i64 unix timestamp
+    #[test]
+    fn test_jwt_timestamp_format_invalid_timestamp() {
+        // Falls outside of DateTime<Utc> representable range
+        let json_data = create_test_jwt_json(i64::MAX);
+        let result = serde_json::from_value::<EveJwtClaims>(json_data);
+
+        assert!(result.is_err());
+
+        assert!(matches!(result,
+            Err(err) if err.to_string().contains("Invalid timestamp")
         ));
     }
 }

--- a/tests/oauth2/util/jwt.rs
+++ b/tests/oauth2/util/jwt.rs
@@ -1,5 +1,5 @@
 use std::fs;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::Duration;
 
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
@@ -8,8 +8,6 @@ use jsonwebtoken::{encode, Algorithm, EncodingKey, Header};
 use oauth2::basic::BasicTokenType;
 use oauth2::{AccessToken, EmptyExtraTokenFields, RefreshToken, StandardTokenResponse};
 use openssl::rsa::Rsa;
-
-use crate::constant::TEST_CLIENT_ID;
 
 pub const RSA_KEY_ID: &str = "JWT-Signature-Key-1";
 
@@ -80,32 +78,7 @@ pub fn create_mock_token_keys(use_alternate_key: bool) -> EveJwtKeys {
 pub fn create_mock_token(
     use_alternate_key: bool,
 ) -> StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType> {
-    // Create JWT claims matching what EVE Online would return
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_secs() as i64;
-
-    let claims = EveJwtClaims {
-        // ESI SSO docs defines 2 different JWT issuers but typically only returns 1 of them at a time
-        // The default defines 2 but for tests we'll define 1 to ensure validation works
-        iss: "https://login.eveonline.com".to_string(),
-        sub: "CHARACTER:EVE:123456789".to_string(),
-        aud: vec![TEST_CLIENT_ID.to_string(), "EVE Online".to_string()],
-        jti: "abc123def456".to_string(),
-        kid: RSA_KEY_ID.to_string(),
-        tenant: "tranquility".to_string(),
-        region: "world".to_string(),
-        exp: now + 900, // Valid for 15 minutes
-        iat: now,
-        scp: vec![
-            "publicData".to_string(),
-            "esi-characters.read_agents_research.v1".to_string(),
-        ],
-        name: "Test Character".to_string(),
-        owner: "123456789".to_string(),
-        azp: TEST_CLIENT_ID.to_string(),
-    };
+    let claims = EveJwtClaims::mock();
 
     create_mock_token_with_claims(use_alternate_key, claims)
 }


### PR DESCRIPTION
The `exp` & `iat` field of `EveJwtClaims` have been changed from being represented as a unix timestamp in `i64` format to instead `DateTime<Utc>` from the [chrono](https://crates.io/crates/chrono) crate.

In order to accomplish this, a custom serializer & deserializer was implemented to convert the i64 unix timestamp format to/from `DateTime<Utc>` as well as relevant tests.

# Features
- `iat` & `exp` fields of `EveJwtClaims` are now represented by `DateTime<Utc>` instead of an `i64` unix timestamp
- `is_expired` method now logs how many seconds ago a token has expired

# Refactors
- The `create_mock_token` method for integration tests now utilizes `EveJwtClaims::mock()` internally to reduce repetition.
- Repetition has been reduced for the `deserialize_scp_tests` module by using a shared `create_mock_json` function which creates the mock json with the provided scope field value.