### PR TITLE
EveJwtClaims::mock() scp field should be Vec::new()

### DIFF
--- a/src/model/oauth2/jwt_claims.rs
+++ b/src/model/oauth2/jwt_claims.rs
@@ -205,10 +205,7 @@ impl EveJwtClaims {
             region: "world".to_string(),
             exp: expires_in_fifteen_minutes,
             iat: created_now,
-            scp: vec![
-                "publicData".to_string(),
-                "esi-characters.read_agents_research.v1".to_string(),
-            ],
+            scp: vec![],
             name: "Test Character".to_string(),
             owner: "123456789".to_string(),
             azp: "client_id".to_string(),

--- a/tests/endpoints/character/get_agents_research.rs
+++ b/tests/endpoints/character/get_agents_research.rs
@@ -1,8 +1,12 @@
-use eve_esi::model::character::CharacterResearchAgent;
+use eve_esi::{
+    model::{character::CharacterResearchAgent, oauth2::EveJwtClaims},
+    oauth2::scope::CharacterScopes,
+    ScopeBuilder,
+};
 use oauth2::TokenResponse;
 
 use crate::{
-    oauth2::util::{jwk_response::get_jwk_success_response, jwt::create_mock_token},
+    oauth2::util::{jwk_response::get_jwk_success_response, jwt::create_mock_token_with_claims},
     util::setup,
 };
 
@@ -35,7 +39,12 @@ async fn test_get_agents_research_success() {
     }];
 
     // Create a mock token for authenticated route
-    let token = create_mock_token(false);
+    let mut mock_claims = EveJwtClaims::mock();
+    mock_claims.scp = ScopeBuilder::new()
+        .character(CharacterScopes::new().read_agents_research())
+        .build();
+
+    let token = create_mock_token_with_claims(false, mock_claims);
     let access_token = token.access_token().secret().to_string();
 
     // Add mock JWT key endpoint as authenticated ESI endpoints validate with keys before request
@@ -101,7 +110,12 @@ async fn test_get_agents_research_500_internal_error() {
         .create();
 
     // Create a mock token for authenticated route
-    let token = create_mock_token(false);
+    let mut mock_claims = EveJwtClaims::mock();
+    mock_claims.scp = ScopeBuilder::new()
+        .character(CharacterScopes::new().read_agents_research())
+        .build();
+
+    let token = create_mock_token_with_claims(false, mock_claims);
     let access_token = token.access_token().secret().to_string();
 
     // Attempt to retrieve research agents

--- a/tests/oauth2/util/jwt.rs
+++ b/tests/oauth2/util/jwt.rs
@@ -78,9 +78,9 @@ pub fn create_mock_token_keys(use_alternate_key: bool) -> EveJwtKeys {
 pub fn create_mock_token(
     use_alternate_key: bool,
 ) -> StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType> {
-    let claims = EveJwtClaims::mock();
+    let mock_claims = EveJwtClaims::mock();
 
-    create_mock_token_with_claims(use_alternate_key, claims)
+    create_mock_token_with_claims(use_alternate_key, mock_claims)
 }
 
 /// Creates a mock token using the provided mock [`EveJwtClaims`]


### PR DESCRIPTION
Modify the `EveJwtClaims::mock()` method to initialize `EveJwtClaims` with the `scp` field set as `Vec::new()` rather than prefilled with `vec!["publicData".to_string(), "esi-characters.read_agents_research.v1".to_string()]`. 

The intended goal is for this change is to make tests both more understandable & predictable by requiring the `scp` field to be set manually going forward when it is needed like so:

```rust
let mut mock_claims = EveJwtClaims::mock();
mock_claims.scp = ScopeBuilder::new()
    .character(CharacterScopes::new().read_agents_research())
    .build();
```