### PR TITLE
Implement logging macro with llvm-cov line coverage workaround

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,33 +154,9 @@ As of August 17th, 2025, `Claude Sonnet 3.7` is the recommended model to use.
 
 ## cargo-llvm-cov Code Coverage & Log Macros
 
-**You may notice that logs are not written as one would expect in the format of:**
-
-```rust
-info!(
-    "Successfully fetched alliance information for alliance ID: {} (took {}ms)",
-    alliance_id,
-    elapsed.as_millis()
-);
-```
-
-**Instead they are written as:**
-
-```rust
-let message = format!(
-    "Successfully fetched alliance information for alliance ID: {} (took {}ms)",
-    alliance_id,
-    elapsed.as_millis()
-);
-
-info!("{}", message);
-```
-
-Why? The tool we use for code coverage, [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov), has issues with
-determing code coverage for multi-line log crate macros. As a result, declaring the message as a variable and passing
-it to the log macro that way has been found to be an acceptable solution until the issue may one day be resolved.
-
-Unfortunately, using `#[cfg_attr(coverage_nightly, coverage(off))]` flag does not work either.
+The tool we use for code coverage, [cargo-llvm-cov](https://github.com/taiki-e/cargo-llvm-cov), has issues with
+determing code coverage for multi-line log crate macros. We've written wrapper macros contained in `src/logging.rs`
+which should be used instead as they resolve the issue with a workaround described in the module documentation.
 
 ## cargo-llvm-cov Code Coverage & Test Assertions
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -45,8 +45,6 @@
 
 use std::sync::Arc;
 
-use log::warn;
-
 use crate::client::ClientRef;
 use crate::config::Config;
 use crate::error::Error;
@@ -309,9 +307,9 @@ fn get_or_default_reqwest_client(
     user_agent: &Option<String>,
 ) -> Result<reqwest::Client, Error> {
     if user_agent.is_some() && client.is_some() {
-        let message = "user_agent is set on `ClientBuilder` but so is reqwest_client. The user_agent will not be applied and should be instead applied to the provided reqwest client if not done so already.";
-
-        warn!("{}", message);
+        warn!(
+            "user_agent is set on `ClientBuilder` but so is reqwest_client. The user_agent will not be applied and should be instead applied to the provided reqwest client if not done so already."
+        );
     }
 
     match client {

--- a/src/endpoints/alliance.rs
+++ b/src/endpoints/alliance.rs
@@ -21,8 +21,6 @@ use crate::{
     Client, Error,
 };
 
-use log::{debug, error, info};
-
 /// Provides methods for accessing character-related endpoints of the EVE Online ESI API.
 ///
 /// For an overview & usage examples, see the [endpoints module documentation](super)
@@ -56,9 +54,7 @@ impl<'a> AllianceApi<'a> {
     pub async fn list_all_alliances(&self) -> Result<Vec<i64>, Error> {
         let url = format!("{}/alliances", self.client.inner.esi_url);
 
-        let message = format!("Fetching list of all alliance IDs from \"{}\"", url);
-
-        debug!("{}", message);
+        debug!("Fetching list of all alliance IDs from \"{}\"", url);
 
         let start_time = Instant::now();
 
@@ -72,24 +68,20 @@ impl<'a> AllianceApi<'a> {
         let elapsed = start_time.elapsed();
         match result {
             Ok(alliances) => {
-                let message = format!(
+                info!(
                     "Successfully fetched IDs for {} alliances (took {}ms)",
                     alliances.len(),
                     elapsed.as_millis()
                 );
 
-                info!("{}", message);
-
                 Ok(alliances)
             }
             Err(err) => {
-                let message = format!(
+                error!(
                     "Failed to fetch list of all alliance IDs after {}ms due to error: {:#?}",
                     elapsed.as_millis(),
                     err
                 );
-
-                error!("{}", message);
 
                 Err(err.into())
             }
@@ -113,12 +105,10 @@ impl<'a> AllianceApi<'a> {
     pub async fn get_alliance_information(&self, alliance_id: i64) -> Result<Alliance, Error> {
         let url = format!("{}/alliances/{}/", self.client.inner.esi_url, alliance_id);
 
-        let message = format!(
+        debug!(
             "Fetching alliance information for alliance ID {} from \"{}\"",
             alliance_id, url
         );
-
-        debug!("{}", message);
 
         let start_time = Instant::now();
 
@@ -132,25 +122,20 @@ impl<'a> AllianceApi<'a> {
         let elapsed = start_time.elapsed();
         match result {
             Ok(alliance) => {
-                let message = format!(
+                info!(
                     "Successfully fetched alliance information for alliance ID: {} (took {}ms)",
                     alliance_id,
                     elapsed.as_millis()
                 );
 
-                info!("{}", message);
-
                 Ok(alliance)
             }
             Err(err) => {
-                let message = format!(
-                    "Failed to fetch alliance information for alliance ID {} after {}ms due to error: {:#?}",
-                    alliance_id,
-                    elapsed.as_millis(),
-                    err
-                );
-
-                error!("{}", message);
+                error!(
+                "Failed to fetch alliance information for alliance ID {} after {}ms due to error: {:#?}",
+                alliance_id,
+                elapsed.as_millis(),
+                err);
 
                 Err(err.into())
             }
@@ -177,12 +162,10 @@ impl<'a> AllianceApi<'a> {
             self.client.inner.esi_url, alliance_id
         );
 
-        let message = format!(
+        debug!(
             "Fetching IDs of all corporations part of alliance ID {} from \"{}\"",
             alliance_id, url
         );
-
-        debug!("{}", message);
 
         let start_time = Instant::now();
 
@@ -196,26 +179,18 @@ impl<'a> AllianceApi<'a> {
         let elapsed = start_time.elapsed();
         match result {
             Ok(corporations) => {
-                let message = format!(
-                    "Successfully fetched IDs for {} corporation(s) part of alliance ID {} (took {}ms)",
-                    corporations.len(),
-                    alliance_id,
-                    elapsed.as_millis()
-                );
-
-                info!("{}", message);
+                info!(     "Successfully fetched IDs for {} corporation(s) part of alliance ID {} (took {}ms)",
+                corporations.len(),
+                alliance_id,
+                elapsed.as_millis());
 
                 Ok(corporations)
             }
             Err(err) => {
-                let message = format!(
-                    "Failed to fetch IDs of all corporations part of alliance ID {} after {}ms due to error: {:#?}",
-                    alliance_id,
-                    elapsed.as_millis(),
-                    err
-                );
-
-                error!("{}", message);
+                error!("Failed to fetch IDs of all corporations part of alliance ID {} after {}ms due to error: {:#?}",
+                alliance_id,
+                elapsed.as_millis(),
+                err);
 
                 Err(err.into())
             }
@@ -242,12 +217,10 @@ impl<'a> AllianceApi<'a> {
             self.client.inner.esi_url, alliance_id
         );
 
-        let message = format!(
+        debug!(
             "Fetching icons URLs for alliance ID {} from \"{}\"",
             alliance_id, url
         );
-
-        debug!("{}", message);
 
         let start_time = Instant::now();
 
@@ -261,25 +234,21 @@ impl<'a> AllianceApi<'a> {
         let elapsed = start_time.elapsed();
         match result {
             Ok(icons) => {
-                let message = format!(
+                info!(
                     "Successfully fetched icon URLs for alliance ID {} (took {}ms)",
                     alliance_id,
                     elapsed.as_millis()
                 );
 
-                info!("{}", message);
-
                 Ok(icons)
             }
             Err(err) => {
-                let message = format!(
+                error!(
                     "Failed to fetch icon URLs for alliance ID {} after {}ms due to error: {:#?}",
                     alliance_id,
                     elapsed.as_millis(),
                     err
                 );
-
-                error!("{}", message);
 
                 Err(err.into())
             }

--- a/src/endpoints/character.rs
+++ b/src/endpoints/character.rs
@@ -15,8 +15,6 @@
 
 use std::time::Instant;
 
-use log::{debug, error, info};
-
 use crate::error::Error;
 use crate::oauth2::scope::CharacterScopes;
 use crate::{Client, ScopeBuilder};
@@ -62,12 +60,10 @@ impl<'a> CharacterApi<'a> {
     ) -> Result<Character, Error> {
         let url = format!("{}/characters/{}/", self.client.inner.esi_url, character_id);
 
-        let message = format!(
+        debug!(
             "Fetching character information for character ID {} from \"{}\"",
             character_id, url
         );
-
-        debug!("{}", message);
 
         let start_time = Instant::now();
 
@@ -81,25 +77,19 @@ impl<'a> CharacterApi<'a> {
         let elapsed = start_time.elapsed();
         match result {
             Ok(character) => {
-                let message = format!(
+                info!(
                     "Successfully fetched character information for character ID: {} (took {}ms)",
                     character_id,
                     elapsed.as_millis()
                 );
 
-                info!("{}", message);
-
                 Ok(character)
             }
             Err(err) => {
-                let message = format!(
-                    "Failed to fetch character information for character ID {} after {}ms due to error: {:#?}",
-                        character_id,
-                        elapsed.as_millis(),
-                        err
-                );
-
-                error!("{}", message);
+                error!(          "Failed to fetch character information for character ID {} after {}ms due to error: {:#?}",
+                    character_id,
+                    elapsed.as_millis(),
+                    err);
 
                 Err(err.into())
             }
@@ -126,13 +116,11 @@ impl<'a> CharacterApi<'a> {
     ) -> Result<Vec<CharacterAffiliation>, Error> {
         let url = format!("{}/characters/affiliation/", self.client.inner.esi_url);
 
-        let message = format!(
+        debug!(
             "Fetching character affiliations for {} characters from \"{}\"",
             character_ids.len(),
             url
         );
-
-        debug!("{}", message);
 
         let start_time = Instant::now();
 
@@ -146,25 +134,19 @@ impl<'a> CharacterApi<'a> {
         let elapsed = start_time.elapsed();
         match result {
             Ok(affiliations) => {
-                let message = format!(
+                info!(
                     "Successfully fetched character affiliations for {} character(s) (took {}ms)",
                     elapsed.as_millis(),
                     character_ids.len()
                 );
 
-                info!("{}", message);
-
                 Ok(affiliations)
             }
             Err(err) => {
-                let message = format!(
-                    "Failed to fetch character affiliations for {} character(s) after {}ms due to error: {:#?}",
-                    character_ids.len(),
-                    elapsed.as_millis(),
-                    err
-                );
-
-                error!("{}", message);
+                error!(                    "Failed to fetch character affiliations for {} character(s) after {}ms due to error: {:#?}",
+                character_ids.len(),
+                elapsed.as_millis(),
+                err);
 
                 Err(err.into())
             }
@@ -203,11 +185,10 @@ impl<'a> CharacterApi<'a> {
             .character(CharacterScopes::new().read_agents_research())
             .build();
 
-        let message = format!(
+        debug!(
             "Fetching research agents for character ID {} from \"{}\"",
             character_id, url
         );
-        debug!("{}", message);
 
         let start_time = Instant::now();
 
@@ -225,26 +206,20 @@ impl<'a> CharacterApi<'a> {
         let elapsed = start_time.elapsed();
         match result {
             Ok(research_agents) => {
-                let message = format!(
+                info!(
                     "Successfully fetched {} research agents for character ID: {} (took {}ms)",
                     research_agents.len(),
                     character_id,
                     elapsed.as_millis()
                 );
 
-                info!("{}", message);
-
                 Ok(research_agents)
             }
             Err(err) => {
-                let message = format!(
-                    "Failed to fetch research agents for character ID {} after {}ms due to error: {:#?}",
-                        character_id,
-                        elapsed.as_millis(),
-                        err
-                );
-
-                error!("{}", message);
+                error!(                  "Failed to fetch research agents for character ID {} after {}ms due to error: {:#?}",
+                    character_id,
+                    elapsed.as_millis(),
+                    err);
 
                 Err(err.into())
             }

--- a/src/endpoints/corporation.rs
+++ b/src/endpoints/corporation.rs
@@ -13,8 +13,6 @@
 
 use std::time::Instant;
 
-use log::{debug, error, info};
-
 use crate::error::Error;
 use crate::model::corporation::Corporation;
 use crate::Client;
@@ -63,12 +61,10 @@ impl<'a> CorporationApi<'a> {
             self.client.inner.esi_url, corporation_id
         );
 
-        let message = format!(
+        debug!(
             "Fetching corporation information for corporation ID {} from \"{}\"",
             corporation_id, url
         );
-
-        debug!("{}", message);
 
         let start_time = Instant::now();
 
@@ -82,24 +78,16 @@ impl<'a> CorporationApi<'a> {
         let elapsed = start_time.elapsed();
         match result {
             Ok(corporation) => {
-                let message = format!(
-                    "Successfully fetched corporation information for corporation ID: {} (took {}ms)",
-                    corporation_id,
-                    elapsed.as_millis()
-                );
-
-                info!("{}", message);
+                info!(                    "Successfully fetched corporation information for corporation ID: {} (took {}ms)",
+                corporation_id,
+                elapsed.as_millis());
 
                 Ok(corporation)
             }
             Err(err) => {
-                let message = format!(
-                    "Successfully fetched corporation information for corporation ID: {} (took {}ms)",
-                    corporation_id,
-                    elapsed.as_millis()
-                );
-
-                error!("{}", message);
+                error!(                    "Successfully fetched corporation information for corporation ID: {} (took {}ms)",
+                corporation_id,
+                elapsed.as_millis());
 
                 Err(err.into())
             }

--- a/src/esi/util.rs
+++ b/src/esi/util.rs
@@ -17,8 +17,7 @@ impl<'a> EsiApi<'a> {
         required_scopes: Vec<String>,
     ) -> Result<(), Error> {
         if self.client.inner.esi_validate_token_before_request {
-            let message = "Validating token prior to expiration & scope checks";
-            log::debug!("{}", message);
+            debug!("Validating token prior to expiration & scope checks");
 
             let claims = self
                 .client
@@ -30,8 +29,7 @@ impl<'a> EsiApi<'a> {
 
             check_token_scopes(&claims, required_scopes)?;
 
-            let message = "Access token passed validation, expiration, and scope checks successfully prior to authenticated ESI request.";
-            log::debug!("{}", message);
+            debug!("Access token passed validation, expiration, and scope checks successfully prior to authenticated ESI request.");
         };
 
         Ok(())
@@ -43,17 +41,15 @@ pub(super) fn check_token_expiration(access_token_claims: &EveJwtClaims) -> Resu
     if access_token_claims.is_expired() {
         let error = OAuthError::AccessTokenExpired();
 
-        let message = format!(
+        error!(
             "Failed to make request to authenticated ESI route due to token being expired: {:?}",
             error
         );
-        log::error!("{}", message);
 
         return Err(Error::OAuthError(error));
     }
 
-    let message = "Checked access token for expiration prior to authenticated ESI request, token is not expired.";
-    log::trace!("{}", message);
+    trace!("Checked access token for expiration prior to authenticated ESI request, token is not expired.");
 
     Ok(())
 }
@@ -66,17 +62,12 @@ pub(super) fn check_token_scopes(
     if !access_token_claims.has_scopes(&required_scopes) {
         let error = OAuthError::AccessTokenMissingScopes(required_scopes);
 
-        let message = format!(
-            "Failed to make request to authenticated ESI route due to missing required scopes: {:?}", error
-
-        );
-        log::error!("{}", message);
+        error!("Failed to make request to authenticated ESI route due to missing required scopes: {:?}", error);
 
         return Err(Error::OAuthError(error));
     }
 
-    let message = format!("Checked access token for required scopes prior to authenticated ESI request, all required scopes are present: {:?}", required_scopes);
-    log::trace!("{}", message);
+    trace!("Checked access token for required scopes prior to authenticated ESI request, all required scopes are present: {:?}", required_scopes);
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,9 @@
 //!     .expect("Failed to build Client");
 //! ```
 
+#[macro_use]
+mod logging;
+
 pub mod builder;
 pub mod client;
 pub mod config;

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,63 @@
+//! # EVE ESI Logging Macros
+//!
+//! We use [llvm-cov](https://github.com/taiki-e/cargo-llvm-cov) to determine code coverage for this
+//! crate. Unfortunately, it marks `log::macro!` as uncovered with multi-line text. The solution we've
+//! found so far is to use `format!()` on the message first then pass it as `log::macro!("{}", message)`
+//! which serves as a workaround to the code coverage issue.
+//!
+//! This module implements a macro for internal usage to make the above process less verbose.
+
+/// [`log::info!`] wrapper, see [`self`] for explanation
+macro_rules! info {
+    ($fmt:expr) => {
+        log::info!("{}", $fmt);
+    };
+    ($fmt:expr, $($arg:tt)*) => {
+        let message = format!($fmt, $($arg)*);
+        log::info!("{}", message);
+    };
+}
+
+/// [`log::warn!`] wrapper, see [`self`] for explanation
+macro_rules! warn {
+    ($fmt:expr) => {
+        log::warn!("{}", $fmt);
+    };
+    ($fmt:expr, $($arg:tt)*) => {
+        let message = format!($fmt, $($arg)*);
+        log::warn!("{}", message);
+    };
+}
+
+/// [`log::error!`] wrapper, see [`self`] for explanation
+macro_rules! error {
+    ($fmt:expr) => {
+        log::error!("{}", $fmt);
+    };
+    ($fmt:expr, $($arg:tt)*) => {
+        let message = format!($fmt, $($arg)*);
+        log::error!("{}", message);
+    };
+}
+
+/// [`log::debug!`] wrapper, see [`self`] for explanation
+macro_rules! debug {
+    ($fmt:expr) => {
+        log::debug!("{}", $fmt);
+    };
+    ($fmt:expr, $($arg:tt)*) => {
+        let message = format!($fmt, $($arg)*);
+        log::debug!("{}", message);
+    };
+}
+
+/// [`log::trace!`] wrapper, see [`self`] for explanation
+macro_rules! trace {
+    ($fmt:expr) => {
+        log::trace!("{}", $fmt);
+    };
+    ($fmt:expr, $($arg:tt)*) => {
+        let message = format!($fmt, $($arg)*);
+        log::trace!("{}", message);
+    };
+}

--- a/src/model/oauth2/jwt_claims.rs
+++ b/src/model/oauth2/jwt_claims.rs
@@ -89,7 +89,8 @@ impl EveJwtClaims {
                 "The `sub` field segment length is {} but the expected length is 2",
                 segments_len,
             );
-            log::error!("{}", message);
+
+            error!(message);
 
             return Err(Error::OAuthError(OAuthError::CharacterIdParseError(
                 message,
@@ -100,7 +101,8 @@ impl EveJwtClaims {
             Ok(character_id) => Ok(character_id),
             Err(err) => {
                 let message = format!("Failed to parse `sub` field to i64 due to error: {}", err);
-                log::error!("{}", message);
+
+                error!(message);
 
                 Err(Error::OAuthError(OAuthError::CharacterIdParseError(
                     message,
@@ -124,23 +126,22 @@ impl EveJwtClaims {
 
         if now < token_expiration {
             let time_remaining = self.exp - now;
-            let message = format!(
+
+            debug!(
                 "Checked token for expiration, token for character ID {} is not yet expired, expiration in {}s",
                 character_id,
                 time_remaining.num_seconds()
             );
-            log::debug!("{}", message);
 
             return false;
         }
 
         let time_remaining = now - self.exp;
-        let message = format!(
+        debug!(
             "Checked token for expiration, token for character ID {} is expired, expired {}s ago",
             character_id,
             time_remaining.num_seconds()
         );
-        log::debug!("{}", message);
 
         true
     }
@@ -167,22 +168,20 @@ impl EveJwtClaims {
         for expected_scope in scopes {
             if !self.scp.iter().any(|scope| scope == expected_scope) {
                 // One of the expected scopes is missing
-                let message = format!(
+                debug!(
                     "Token for character ID {} is missing scope: {}",
                     character_id, expected_scope
                 );
-                log::debug!("{}", message);
 
                 return false;
             }
         }
 
         // All expected scopes were found
-        let message = format!(
+        debug!(
             "Token for character ID {} has all expected scopes",
             character_id
         );
-        log::debug!("{}", message);
 
         true
     }

--- a/src/oauth2/jwk/cache.rs
+++ b/src/oauth2/jwk/cache.rs
@@ -17,7 +17,6 @@
 use std::time::Instant;
 use std::{sync::atomic::AtomicBool, time::Duration};
 
-use log::{debug, info, trace};
 use tokio::sync::{Notify, RwLock};
 
 use crate::{
@@ -159,9 +158,7 @@ impl JwtKeyCache {
     /// - [`None`] if the cache is empty (no keys have been fetched yet). This typically
     ///   triggers a fetch operation with retry logic when called from higher-level methods.
     pub(super) async fn get_keys(self: &Self) -> Option<(EveJwtKeys, std::time::Instant)> {
-        let message = "Attempting to retrieve JWT keys from cache";
-
-        trace!("{}", message);
+        trace!("Attempting to retrieve JWT keys from cache");
 
         // Retrieve the cache
         let cache = self.cache.read().await;
@@ -170,21 +167,17 @@ impl JwtKeyCache {
         if let Some((keys, timestamp)) = &*cache {
             let elapsed = timestamp.elapsed().as_secs();
 
-            let message = format!(
+            debug!(
                 "Found JWT keys in cache: key_count={}, age={}s",
                 keys.keys.len(),
                 elapsed
             );
 
-            debug!("{}", message);
-
             // Return the keys found in cache
             return Some((keys.clone(), timestamp.clone()));
         }
 
-        let message = "JWT keys cache is empty, keys need to be fetched";
-
-        debug!("{}", message);
+        debug!("JWT keys cache is empty, keys need to be fetched");
 
         // Return None since no data was found in the cache
         None

--- a/src/oauth2/jwk/util.rs
+++ b/src/oauth2/jwk/util.rs
@@ -11,7 +11,6 @@
 //!
 //! See the [module-level documentation](super) for a more detailed overview and usage.
 
-use log::{debug, trace};
 use std::time::Instant;
 
 use crate::oauth2::jwk::cache::JwtKeyCache;
@@ -47,26 +46,22 @@ pub(super) async fn check_refresh_cooldown(jwt_key_cache: &JwtKeyCache) -> Optio
         let is_cooldown = elapsed_secs < config.refresh_cooldown.as_secs();
 
         if is_cooldown {
-            let message = format!(
+            debug!(
                 "Respecting background refresh cooldown: {}s elapsed of {}s required",
                 elapsed_secs,
                 config.refresh_cooldown.as_secs()
             );
-
-            debug!("{}", message);
 
             // Return Some with the remaining cooldown in seconds
             let remaining_cooldown = config.refresh_cooldown.as_secs() - elapsed_secs;
 
             return Some(remaining_cooldown);
         } else {
-            let message = format!(
+            trace!(
                 "Background cooldown period elapsed: {}s passed (required {}s)",
                 elapsed_secs,
                 config.refresh_cooldown.as_secs()
             );
-
-            trace!("{}", message);
 
             // Return None indicating there is no active cooldown
             return None;
@@ -113,7 +108,7 @@ pub(super) fn is_cache_approaching_expiry(jwt_key_cache: &JwtKeyCache, timestamp
     let threshold_seconds = (config.cache_ttl.as_secs() as f64 * threshold_percentage) as u64;
 
     if is_approaching_expiry {
-        let message = format!(
+        debug!(
             "JWT keys cache approaching expiry: elapsed={}s, threshold={}s ({}% of ttl={}s)",
             elapsed_seconds,
             threshold_seconds,
@@ -121,20 +116,14 @@ pub(super) fn is_cache_approaching_expiry(jwt_key_cache: &JwtKeyCache, timestamp
             config.cache_ttl.as_secs()
         );
 
-        debug!("{}", message);
-
         // Return true if cache is approaching expiry
         true
     } else {
-        let message = format!(
-            "JWT keys cache not yet approaching expiry: elapsed={}s, threshold={}s ({}% of ttl={}s)",
-            elapsed_seconds,
-            threshold_seconds,
-            config.background_refresh_threshold,
-            config.cache_ttl.as_secs()
-        );
-
-        trace!("{}", message);
+        trace!(            "JWT keys cache not yet approaching expiry: elapsed={}s, threshold={}s ({}% of ttl={}s)",
+        elapsed_seconds,
+        threshold_seconds,
+        config.background_refresh_threshold,
+        config.cache_ttl.as_secs());
 
         // Return false if cache is not yet approaching expiry
         false
@@ -160,24 +149,20 @@ pub(super) fn is_cache_expired(jwt_key_cache: &JwtKeyCache, timestamp: Instant) 
     let is_expired = timestamp.elapsed().as_millis() >= cache_ttl.as_millis();
 
     if is_expired {
-        let message = format!(
+        debug!(
             "JWT keys cache expired: elapsed={}s, ttl={}s",
             timestamp.elapsed().as_secs(),
             cache_ttl.as_secs()
         );
 
-        debug!("{}", message);
-
         // Return true if cache is not yet expired
         true
     } else {
-        let message = format!(
+        trace!(
             "JWT keys cache valid: elapsed={}s, ttl={}s",
             timestamp.elapsed().as_secs(),
             cache_ttl.as_secs()
         );
-
-        trace!("{}", message);
 
         // Return false if cache is still valid
         false

--- a/src/oauth2/login.rs
+++ b/src/oauth2/login.rs
@@ -5,7 +5,6 @@
 //!
 //! See the [module-level documentation](super) for an overview of EVE Online OAuth2 and usage example.
 
-use log::error;
 use oauth2::{CsrfToken, Scope};
 
 use crate::error::{Error, OAuthError};
@@ -66,12 +65,10 @@ impl<'a> OAuth2Api<'a> {
             // Returns an error if the OAuth2 client is not found due to it not having been configured when
             // building the Client.
             None => {
-                let message = format!(
+                error!(
                     "Error building a login URL: {:#?}",
                     OAuthError::OAuth2NotConfigured
                 );
-
-                error!("{}", message);
 
                 return Err(Error::OAuthError(OAuthError::OAuth2NotConfigured));
             }

--- a/src/oauth2/token.rs
+++ b/src/oauth2/token.rs
@@ -62,7 +62,6 @@
 //! ```
 
 use jsonwebtoken::{DecodingKey, Validation};
-use log::{debug, error, info, trace};
 use oauth2::basic::BasicTokenType;
 use oauth2::{AuthorizationCode, EmptyExtraTokenFields, RefreshToken, StandardTokenResponse};
 
@@ -312,7 +311,7 @@ async fn attempt_validation(client: &Client, token_secret: &str) -> Result<EveJw
         let message: &str =
             "Failed to find RS256 key in JWT key cache when attempting to validate a JWT token.";
 
-        error!("{}", message);
+        error!(message);
 
         Err(Error::OAuthError(OAuthError::NoValidKeyFound(
             message.to_string(),
@@ -323,7 +322,7 @@ async fn attempt_validation(client: &Client, token_secret: &str) -> Result<EveJw
 /// Utility function to retrieve OAuth2 client or return an error
 fn get_oauth_client(client: &Client) -> Result<&OAuth2Client, Error> {
     // Attempt to retrieve OAuth2 client from ESI client
-    trace!("{}", "Attempting to retrieve OAuth2 client from ESI client");
+    trace!("Attempting to retrieve OAuth2 client from ESI client");
 
     match client.inner.oauth2_client {
         Some(ref client) => {


### PR DESCRIPTION
Implements macros utilizing the workaround of using format!() on the message first before passing it to a log crate macro to prevent the line from showing as uncovered by llvm-cov. The macros are defined in `src/logging.rs` which includes an explanation in the module-level documentation of what the macros are for.

Going forward these macros should be used for any and all logging purposes, the codebase has been refactored to implement the usage of these new macros.