### PR TITLE
Use serde_json mock endpoint body for endpoint integration tests

### DIFF
--- a/tests/endpoints/alliance/get_alliance_icon.rs
+++ b/tests/endpoints/alliance/get_alliance_icon.rs
@@ -1,79 +1,49 @@
-use eve_esi::model::alliance::AllianceIcons;
-
 use crate::util::setup;
 
 /// Successful retrieval of alliance icons
-///
-/// # Test Setup
-/// - Setup a basic EsiClient & mock HTTP server
-/// - Create mock alliance icons
-/// - Configure mock server with endpoint returning mock alliance icons
-///
-/// # Assertions
-/// - Assert 1 request was made to the mock server
-/// - Assert result is Ok
 #[tokio::test]
 async fn test_get_alliance_icon_success() {
-    // Setup a basic EsiClient & mock HTTP server
     let (esi_client, mut mock_server) = setup().await;
 
-    // Create mock alliance icons
-    let mock_icons = AllianceIcons {
-        px128x128: "ABCD".to_string(),
-        px64x64: "ABCD".to_string(),
-    };
+    let mock_alliance_icons = serde_json::json!({
+        "px128x128": "ABCD",
+        "px64x64":"ABCD"
+    });
 
-    // Configure mock server with endpoint returning mock alliance icons
-    let mock = mock_server
+    let mock_icons_endpoint = mock_server
         .mock("GET", "/alliances/99013534/icons")
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(serde_json::to_string(&mock_icons).unwrap())
+        .with_body(mock_alliance_icons.to_string())
         .create();
 
-    // Retrieve the list of corporations part of alliance 99013534
     let result = esi_client.alliance().get_alliance_icon(99013534).await;
 
-    // Assert 1 request was made to the mock server
-    mock.assert();
+    // Assert 1 request was made to the mock endpoint
+    mock_icons_endpoint.assert();
 
-    // Assert result is Ok
     assert!(result.is_ok());
 }
 
 /// Receiving an error 404 when attempting to retrieve alliance icons
-///
-/// # Test Setup
-/// - Setup a basic EsiClient & mock HTTP server
-/// - Configure a mock response returning a 404 not found
-///
-/// # Assertions
-/// - Assert 1 request was made to the mock server
-/// - Assert result is error
-/// - Assert error is due to not found error
 #[tokio::test]
 async fn test_get_alliance_icon_not_found() {
-    // Setup a basic EsiClient & mock HTTP server
     let (esi_client, mut mock_server) = setup().await;
 
-    // Configure a mock response returning a 404 not found
-    let mock = mock_server
+    let mock_icons_endpoint = mock_server
         .mock("GET", "/alliances/99013534/icons")
         .with_status(404)
         .with_header("content-type", "application/json")
         .with_body(r#"{"error": "Alliance not found"}"#)
         .create();
 
-    // Retrieve the list of corporations part of alliance 99013534
     let result = esi_client.alliance().get_alliance_icon(99013534).await;
 
-    // Assert 1 request was made to the mock server
-    mock.assert();
+    // Assert 1 request was made to the mock endpoint
+    mock_icons_endpoint.assert();
 
-    // Assert result is error
     assert!(result.is_err());
 
-    // Assert error is due to not found error
     assert!(
         matches!(result, Err(eve_esi::Error::ReqwestError(ref e)) if e.status() == Some(reqwest::StatusCode::NOT_FOUND))
     );

--- a/tests/endpoints/alliance/get_alliance_information.rs
+++ b/tests/endpoints/alliance/get_alliance_information.rs
@@ -1,95 +1,60 @@
-use eve_esi::model::alliance::Alliance;
-
 use crate::util::setup;
 
-/// Tests the successful retrieval of alliance information from a mock EVE ESI server.
-///
-/// # Test Setup
-/// - Setup a basic EsiClient & mock HTTP server
-/// - Create mock alliance data
-/// - Configure mock server with an ESI endpoint returning the mock alliance
-///
-/// # Assertions
-/// - Assert 1 request was made to the mock server
-/// - Assert result is Ok
-/// - Assert received expected alliance data
+/// Successful retrieval of alliance information
 #[tokio::test]
 async fn get_alliance_information() {
-    // Setup a basic EsiClient & mock HTTP server
     let (esi_client, mut mock_server) = setup().await;
 
-    // Create mock alliance data
-    let mock_alliance = Alliance {
-        creator_corporation_id: 98784257,
-        creator_id: 2114794365,
-        faction_id: None,
-        date_founded: "2024-09-25T06:25:58Z".parse().unwrap(),
-        executor_corporation_id: Some(98787881),
-        name: "Autumn.".to_string(),
-        ticker: "AUTMN".to_string(),
-    };
+    let mock_alliance = serde_json::json!({
+        "creator_corporation_id": 98784257,
+        "creator_id": 2114794365,
+        "faction_id": null,
+        "date_founded": "2024-09-25T06:25:58Z",
+        "executor_corporation_id": 98787881,
+        "name": "Autumn.",
+        "ticker": "AUTMN",
+    });
 
-    // Configure mock server with an ESI endpoint returning the mock alliance
-    let mock = mock_server
+    let mock_alliance_endpoint = mock_server
         .mock("GET", "/alliances/99013534/")
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(serde_json::to_string(&mock_alliance).unwrap())
+        .with_body(mock_alliance.to_string())
         .create();
 
-    // Retrieve the alliance
     let result = esi_client
         .alliance()
         .get_alliance_information(99013534)
         .await;
 
-    // Assert 1 request was made to the mock server
-    mock.assert();
+    // Assert 1 request was made to the mock endpoint
+    mock_alliance_endpoint.assert();
 
-    // Assert result is Ok
     assert!(result.is_ok());
-
-    // Assert received expected alliance data
-    let alliance = result.unwrap();
-    assert_eq!(alliance, mock_alliance);
 }
 
-/// Tests receiving a 404 error when attempting to retrieve alliance information from a mock EVE ESI server.
-///
-/// # Test Setup
-/// - Setup a basic EsiClient & mock HTTP server
-/// - Configure mock server with an ESI endpoint returning 404 not found
-///
-/// # Assertions
-/// - Assert 1 request was made to the mock server
-/// - Assert result is error
-/// - Assert error is due to internal server error
+/// Receiving a 404 error when attempting to retrieve alliance information
 #[tokio::test]
 async fn get_alliance_information_not_found() {
-    // Setup a basic EsiClient & mock HTTP server
     let (esi_client, mut mock_server) = setup().await;
 
-    // Configure a mock response returning a 404 not found
-    let mock = mock_server
+    let mock_alliance_endpoint = mock_server
         .mock("GET", "/alliances/99999999/")
         .with_status(404)
         .with_header("content-type", "application/json")
         .with_body(r#"{"error": "Alliance not found"}"#)
         .create();
 
-    // Retrieve the alliance
     let result = esi_client
         .alliance()
         .get_alliance_information(99999999)
         .await;
 
-    // Assert 1 request was made to the mock server
-    mock.assert();
+    // Assert 1 request was made to the mock endpoint
+    mock_alliance_endpoint.assert();
 
-    // Assert result is error
     assert!(result.is_err());
 
-    // Assert error is due to internal server error
     assert!(
         matches!(result, Err(eve_esi::Error::ReqwestError(ref e)) if e.status() == Some(reqwest::StatusCode::NOT_FOUND))
     );

--- a/tests/endpoints/alliance/list_all_alliances.rs
+++ b/tests/endpoints/alliance/list_all_alliances.rs
@@ -1,57 +1,32 @@
 use crate::util::setup;
 
 /// Successful retrieval of list of alliance IDs
-///
-/// # Test Setup
-/// - Setup a basic EsiClient & mock HTTP server
-/// - Create mock Vec of alliance IDs
-/// - Configure mock server with endpoint returning mock alliance IDs
-///
-/// # Assertions
-/// - Assert 1 request was made to the mock server
-/// - Assert result is Ok
 #[tokio::test]
 async fn test_list_all_alliances_success() {
-    // Setup a basic EsiClient & mock HTTP server
     let (esi_client, mut mock_server) = setup().await;
 
-    // Create mock Vec of alliance IDs
-    let mock_alliance_ids = vec![1, 2, 3, 4, 5, 6, 7, 8, 9];
+    let mock_alliance_ids = serde_json::json!([1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
-    // Configure mock server with endpoint returning mock alliance IDs
-    let mock = mock_server
+    let mock_alliance_endpoint = mock_server
         .mock("GET", "/alliances")
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(serde_json::to_string(&mock_alliance_ids).unwrap())
+        .with_body(mock_alliance_ids.to_string())
         .create();
 
-    // Retrieve the list of alliances
     let result = esi_client.alliance().list_all_alliances().await;
 
-    // Assert 1 request was made to the mock server
-    mock.assert();
+    // Assert 1 request was made to the mock endpoint
+    mock_alliance_endpoint.assert();
 
-    // Assert result is Ok
     assert!(result.is_ok());
 }
 
 /// Receiving an error 500 when calling list_all_alliances()
-///
-/// # Test Setup
-/// - Setup a basic EsiClient & mock HTTP server
-/// - Configure mock server with an ESI endpoint returning a 600 internal server error
-///
-/// # Assertions
-/// - Assert 1 request was made to the mock server
-/// - Assert result is error
-/// - Assert error is due to internal server error
 #[tokio::test]
 async fn test_list_all_alliances_internal_error() {
-    // Setup a basic EsiClient & mock HTTP server
     let (esi_client, mut mock_server) = setup().await;
 
-    // Configure a mock response returning a 500 internal server error
     let mock = mock_server
         .mock("GET", "/alliances")
         .with_status(500)
@@ -59,16 +34,13 @@ async fn test_list_all_alliances_internal_error() {
         .with_body(r#"{"error": "Internal server error"}"#)
         .create();
 
-    // Retrieve the list of alliances
     let result = esi_client.alliance().list_all_alliances().await;
 
-    // Assert 1 request was made to the mock server
+    // Assert 1 request was made to the mock endpoint
     mock.assert();
 
-    // Assert result is error
     assert!(result.is_err());
 
-    // Assert error is due to internal server error
     assert!(
         matches!(result, Err(eve_esi::Error::ReqwestError(ref e)) if e.status() == Some(reqwest::StatusCode::INTERNAL_SERVER_ERROR))
     );

--- a/tests/endpoints/alliance/list_alliance_corporations.rs
+++ b/tests/endpoints/alliance/list_alliance_corporations.rs
@@ -1,80 +1,54 @@
 use crate::util::setup;
 
 /// Successful retrieval of IDs of corporations part of an alliance
-///
-/// # Test Setup
-/// - Setup a basic EsiClient & mock HTTP server
-/// - Create mock Vec of corporation IDs
-/// - Configure mock server with an ESI endpoint returning a mock list of corporation IDs
-///
-/// # Assertions
-/// - Assert 1 request was made to the mock server
-/// - Assert result is Ok
 #[tokio::test]
 async fn test_list_alliance_corporations_success() {
-    // Setup a basic EsiClient & mock HTTP server
     let (esi_client, mut mock_server) = setup().await;
 
-    // Create mock Vec of corporation IDs
-    let mock_corporation_ids = vec![1, 2, 3, 4, 5, 6, 7, 8, 9];
+    let mock_alliance_corporation_ids = serde_json::json!([1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
-    // Configure mock server with an ESI endpoint returning a mock list of corporation IDs
-    let mock = mock_server
+    let mock_alliance_corporations_endpoint = mock_server
         .mock("GET", "/alliances/99013534/corporations")
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(serde_json::to_string(&mock_corporation_ids).unwrap())
+        .with_body(mock_alliance_corporation_ids.to_string())
         .create();
 
-    // Retrieve the list of corporations part of alliance 99013534
+    let alliance_id = 99013534;
     let result = esi_client
         .alliance()
-        .list_alliance_corporations(99013534)
+        .list_alliance_corporations(alliance_id)
         .await;
 
-    // Assert 1 request was made to the mock server
-    mock.assert();
+    // Assert 1 request was made to the mock endpoint
+    mock_alliance_corporations_endpoint.assert();
 
-    // Assert result is Ok
     assert!(result.is_ok());
 }
 
 /// Receiving an error 404 when calling list_alliance_corporations()
-///
-/// # Test Setup
-/// - Setup a basic EsiClient & mock HTTP server
-/// - Configure a mock response returning a 404 not found
-///
-/// # Assertions
-/// - Assert 1 request was made to the mock server
-/// - Assert result is error
-/// - Assert error is due to not found error
 #[tokio::test]
 async fn test_list_alliance_corporations_not_found() {
-    // Setup a basic EsiClient & mock HTTP server
     let (esi_client, mut mock_server) = setup().await;
 
-    // Configure a mock response returning a 404 not found
-    let mock = mock_server
+    let mock_alliance_corporations_endpoint = mock_server
         .mock("GET", "/alliances/99013534/corporations")
         .with_status(404)
         .with_header("content-type", "application/json")
         .with_body(r#"{"error": "Alliance not found"}"#)
         .create();
 
-    // Retrieve the list of corporations part of alliance 99013534
+    let alliance_id = 99013534;
     let result = esi_client
         .alliance()
-        .list_alliance_corporations(99013534)
+        .list_alliance_corporations(alliance_id)
         .await;
 
-    // Assert 1 request was made to the mock server
-    mock.assert();
+    // Assert 1 request was made to the mock endpoint
+    mock_alliance_corporations_endpoint.assert();
 
-    // Assert result is error
     assert!(result.is_err());
 
-    // Assert error is due to not found error
     assert!(
         matches!(result, Err(eve_esi::Error::ReqwestError(ref e)) if e.status() == Some(reqwest::StatusCode::NOT_FOUND))
     );

--- a/tests/endpoints/character/character_affiliation.rs
+++ b/tests/endpoints/character/character_affiliation.rs
@@ -1,81 +1,50 @@
-use eve_esi::model::character::CharacterAffiliation;
-
 use crate::util::setup;
 
-/// Tests the successful retrieval of character affiliations from a mock EVE ESI server.
-///
-/// # Test Setup
-/// - Setup a basic EsiClient & mock HTTP server
-/// - Create mock character affiliation data
-/// - Configure mock server with an ESI endpoint returning the mock character affiliations
-///
-/// # Assertions
-/// - Assert 1 request was made to the mock server
-/// - Assert result is Ok
-/// - Assert received expected character affiliation data
+/// Successful retrieval of character affiliations
 #[tokio::test]
 async fn character_affiliation() {
-    // Setup a basic EsiClient & mock HTTP server
     let (esi_client, mut mock_server) = setup().await;
 
-    // Create mock character affiliation data
-    let mock_character_affiliations = vec![
-        CharacterAffiliation {
-            character_id: 2114794365,
-            corporation_id: 98785281,
-            alliance_id: Some(99013534),
-            faction_id: None,
+    let mock_character_affiliations = serde_json::json!([
+        {
+            "character_id": 2114794365,
+            "corporation_id": 98785281,
+            "alliance_id": 99013534,
+            "faction_id": null,
         },
-        CharacterAffiliation {
-            character_id: 2117053828,
-            corporation_id: 98785281,
-            alliance_id: Some(99013534),
-            faction_id: None,
+        {
+            "character_id": 2117053828,
+            "corporation_id": 98785281,
+            "alliance_id": 99013534,
+            "faction_id": null,
         },
-    ];
+    ]);
 
-    // Configure mock server with an ESI endpoint returning the mock character affiliations
-    let mock = mock_server
+    let mock_character_affiliations_endpoint = mock_server
         .mock("POST", "/characters/affiliation/")
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(serde_json::to_string(&mock_character_affiliations).unwrap())
+        .with_body(mock_character_affiliations.to_string())
         .create();
 
-    // Retrieve the character affiliations
+    let character_ids = vec![2114794365, 2117053828];
     let result = esi_client
         .character()
-        .character_affiliation(vec![2114794365, 2117053828])
+        .character_affiliation(character_ids)
         .await;
 
-    // Assert 1 request was made to the mock server
-    mock.assert();
+    // Assert 1 request was made to the mock endpoint
+    mock_character_affiliations_endpoint.assert();
 
-    // Assert result is Ok
     assert!(result.is_ok());
-
-    // Assert received expected character affiliation data
-    let character_affiliations = result.unwrap();
-    assert_eq!(character_affiliations, mock_character_affiliations);
 }
 
-/// Tests the failed retrieval of character affiliations due to a bad request error
-///
-/// # Test Setup
-/// - Setup a basic EsiClient & mock HTTP server
-/// - Configure mock server with an ESI endpoint returning 400 bad request
-///
-/// # Assertions
-/// - Assert 1 request was made to the mock server
-/// - Assert result is error
-/// - Assert reqwest error is due to status BAD_REQUEST
+/// Failed retrieval of character affiliations due to a bad request error
 #[tokio::test]
 async fn character_affiliation_bad_request() {
-    // Setup a basic EsiClient & mock HTTP server
     let (esi_client, mut mock_server) = setup().await;
 
-    // Configure mock server with an ESI endpoint returning 400 bad request
-    let mock = mock_server
+    let mock_character_affiliations_endpoint = mock_server
         .mock("POST", "/characters/affiliation/")
         .with_status(400)
         .with_header("content-type", "application/json")
@@ -86,25 +55,18 @@ async fn character_affiliation_bad_request() {
         )
         .create();
 
-    // Retrieve the character affiliations
-    let result = esi_client.character().character_affiliation(vec![0]).await;
+    let character_ids = vec![0];
+    let result = esi_client
+        .character()
+        .character_affiliation(character_ids)
+        .await;
 
-    // Assert 1 request was made to the mock server
-    mock.assert();
+    // Assert 1 request was made to the mock endpoint
+    mock_character_affiliations_endpoint.assert();
 
-    // Assert result is error
     assert!(result.is_err());
-    match result {
-        Err(eve_esi::Error::ReqwestError(err)) => {
-            // Assert reqwest error is due to status BAD_REQUEST
-            assert!(err.status().is_some());
-            assert_eq!(err.status().unwrap(), reqwest::StatusCode::BAD_REQUEST);
-        }
-        err => {
-            panic!(
-                "Expected ReqwestError, got different error type: {:#?}",
-                err
-            )
-        }
-    }
+
+    assert!(
+        matches!(result, Err(eve_esi::Error::ReqwestError(ref e)) if e.status() == Some(reqwest::StatusCode::BAD_REQUEST))
+    );
 }

--- a/tests/endpoints/character/get_agents_research.rs
+++ b/tests/endpoints/character/get_agents_research.rs
@@ -1,8 +1,4 @@
-use eve_esi::{
-    model::{character::CharacterResearchAgent, oauth2::EveJwtClaims},
-    oauth2::scope::CharacterScopes,
-    ScopeBuilder,
-};
+use eve_esi::{model::oauth2::EveJwtClaims, oauth2::scope::CharacterScopes, ScopeBuilder};
 use oauth2::TokenResponse;
 
 use crate::{
@@ -10,142 +6,94 @@ use crate::{
     util::setup,
 };
 
-/// Successful retrieval of character research agents via authenticated ESI route
-///
-/// # Test Setup
-/// - Setup a basic EsiClient & mock HTTP server
-/// - Create mock character research agents
-/// - Create a mock token for authenticated route
-/// - Add mock JWT key endpoint as authenticated ESI endpoints validate with keys before request
-/// - Configure mock server with authenticated ESI endpoint returning the research agents
-///
-/// # Assertions
-/// - Assert JWT keys were fetched for token validation prior to request
-/// - Assert 1 request & expected access token was sent to the mock server
-/// - Assert result is Ok
-/// - Assert received expected character research agents
+/// Successful retrieval of character research agents
 #[tokio::test]
 async fn test_get_agents_research_success() {
-    // Setup a basic EsiClient & mock HTTP server
     let (esi_client, mut mock_server) = setup().await;
 
-    // Create mock character research agents
-    let mock_research_agents = vec![CharacterResearchAgent {
-        agent_id: 100,
-        points_per_day: 1.07832178,
-        remainder_points: 1.07832178,
-        skill_type_id: 100,
-        started_at: "2018-12-20T16:11:54Z".parse().unwrap(),
-    }];
+    let mock_research_agents = serde_json::json!([{
+        "agent_id": 100,
+        "points_per_day": 1.07832178,
+        "remainder_points": 1.07832178,
+        "skill_type_id": 100,
+        "started_at": "2018-12-20T16:11:54Z",
+    }]);
 
-    // Create a mock token for authenticated route
-    let mut mock_claims = EveJwtClaims::mock();
-    mock_claims.scp = ScopeBuilder::new()
+    let mut mock_access_token_claims = EveJwtClaims::mock();
+    mock_access_token_claims.scp = ScopeBuilder::new()
         .character(CharacterScopes::new().read_agents_research())
         .build();
+    let token = create_mock_token_with_claims(false, mock_access_token_claims);
 
-    let token = create_mock_token_with_claims(false, mock_claims);
     let access_token = token.access_token().secret().to_string();
 
-    // Add mock JWT key endpoint as authenticated ESI endpoints validate with keys before request
-    let mock_jwk = get_jwk_success_response(&mut mock_server, 1);
+    // Create JWT key endpoint for token validation before request
+    let mock_jwt_key_endpoint = get_jwk_success_response(&mut mock_server, 1);
 
-    // Configure mock server with authenticated ESI endpoint returning the research agents
-    let mock = mock_server
+    let mock_research_agents_endpoint = mock_server
         .mock("GET", "/characters/2114794365/agents_research")
         .with_status(200)
         .with_header("content-type", "application/json")
-        // Expect proper access token for authenticated route
+        // Expect access token for authenticated route
         .with_header("Authorization", &format!("Bearer {}", access_token))
-        .with_body(serde_json::to_string(&mock_research_agents).unwrap())
+        .with_body(mock_research_agents.to_string())
         .create();
 
-    // Retrieve the character research agents using access token
+    let character_id = 2114794365;
     let result = esi_client
         .character()
-        .get_agents_research(2114794365, &access_token)
+        .get_agents_research(character_id, &access_token)
         .await;
 
     // Assert JWT keys were fetched for token validation prior to request
-    mock_jwk.assert();
+    mock_jwt_key_endpoint.assert();
 
-    // Assert 1 request & expected access token was sent to the mock server
-    mock.assert();
+    // Assert 1 request & expected access token was received for mock endpoint
+    mock_research_agents_endpoint.assert();
 
-    // Assert result is Ok
     assert!(result.is_ok());
-
-    // Assert received expected character research agents
-    let research_agents = result.unwrap();
-    assert_eq!(research_agents, mock_research_agents);
 }
 
-/// Error handling when server returns 500 internal error
-///
-/// # Test Setup
-/// - Setup a basic EsiClient & mock HTTP server
-/// - Create a mock token for authenticated route
-/// - Add mock JWT key endpoint as authenticated ESI endpoints validate with keys before request
-/// - Configure mock server with an authenticated ESI endpoint returning 500 internal server error
-///
-/// # Assertions
-/// - Assert JWT keys were fetched for token validation prior to request
-/// - Assert 1 request was made to the mock server
-/// - Assert result is error
-/// - Assert reqwest error is due to status INTERNAL_SERVER_ERROR
+/// Failed retrieval of character affiliations due to an internal server error
 #[tokio::test]
 async fn test_get_agents_research_500_internal_error() {
-    // Setup a basic EsiClient & mock HTTP server
     let (esi_client, mut mock_server) = setup().await;
 
-    // Add mock JWT key endpoint as authenticated ESI endpoints validate with keys before request
-    let mock_jwk = get_jwk_success_response(&mut mock_server, 1);
+    let mut mock_access_token_claims = EveJwtClaims::mock();
+    mock_access_token_claims.scp = ScopeBuilder::new()
+        .character(CharacterScopes::new().read_agents_research())
+        .build();
+    let token = create_mock_token_with_claims(false, mock_access_token_claims);
 
-    // Configure mock server with an authenticated ESI endpoint returning 500 internal server error
-    let mock = mock_server
+    let access_token = token.access_token().secret().to_string();
+
+    // Create JWT key endpoint for token validation before request
+    let mock_jwt_key_endpoint = get_jwk_success_response(&mut mock_server, 1);
+
+    let mock_research_agents_endpoint = mock_server
         .mock("GET", "/characters/2114794365/agents_research")
         .with_status(500)
         .with_header("content-type", "application/json")
+        // Expect access token for authenticated route
+        .with_header("Authorization", &format!("Bearer {}", access_token))
         .with_body(r#"{"error": "Internal server error"}"#)
         .create();
 
-    // Create a mock token for authenticated route
-    let mut mock_claims = EveJwtClaims::mock();
-    mock_claims.scp = ScopeBuilder::new()
-        .character(CharacterScopes::new().read_agents_research())
-        .build();
-
-    let token = create_mock_token_with_claims(false, mock_claims);
-    let access_token = token.access_token().secret().to_string();
-
-    // Attempt to retrieve research agents
+    let character_id = 2114794365;
     let result = esi_client
         .character()
-        .get_agents_research(2114794365, &access_token)
+        .get_agents_research(character_id, &access_token)
         .await;
 
     // Assert JWT keys were fetched for token validation prior to request
-    mock_jwk.assert();
+    mock_jwt_key_endpoint.assert();
 
-    // Assert 1 request was made to the mock server
-    mock.assert();
+    // Assert 1 request & expected access token was received for mock endpoint
+    mock_research_agents_endpoint.assert();
 
-    // Assert result is error
     assert!(result.is_err());
-    match result {
-        Err(eve_esi::Error::ReqwestError(err)) => {
-            // Assert reqwest error is due to status INTERNAL_SERVER_ERROR
-            assert!(err.status().is_some());
-            assert_eq!(
-                err.status().unwrap(),
-                reqwest::StatusCode::INTERNAL_SERVER_ERROR
-            );
-        }
-        err => {
-            panic!(
-                "Expected ReqwestError, got different error type: {:#?}",
-                err
-            )
-        }
-    }
+
+    assert!(
+        matches!(result, Err(eve_esi::Error::ReqwestError(ref e)) if e.status() == Some(reqwest::StatusCode::INTERNAL_SERVER_ERROR))
+    );
 }

--- a/tests/endpoints/character/get_character_public_information.rs
+++ b/tests/endpoints/character/get_character_public_information.rs
@@ -1,108 +1,67 @@
-use eve_esi::model::character::Character;
-
 use crate::util::setup;
 
 /// Tests the successful retrieval of character information from a mock EVE ESI server.
-///
-/// # Test Setup
-/// - Setup a basic EsiClient & mock HTTP server
-/// - Create mock character data
-/// - Configure mock server with an ESI endpoint returning the mock character data
-///
-/// # Assertions
-/// - Assert 1 request was made to the mock server
-/// - Assert result is Ok
-/// - Assert received expected character data
 #[tokio::test]
 async fn get_character_public_information() {
-    // Setup a basic EsiClient & mock HTTP server
     let (esi_client, mut mock_server) = setup().await;
 
-    // Create mock character data
-    let mock_character = Character {
-        alliance_id: Some(99013534),
-        birthday: "2018-12-20T16:11:54Z".parse().unwrap(),
-        bloodline_id: 7,
-        corporation_id: 98785281,
-        description: Some("description".to_string()),
-        faction_id: None,
-        gender: "male".to_string(),
-        name: "Hyziri".to_string(),
-        race_id: 8,
-        security_status: Some(-0.100373643),
-        title: Some("Title".to_string()),
-    };
+    let mock_character = serde_json::json!({
+        "alliance_id": 99013534,
+        "birthday": "2018-12-20T16:11:54Z",
+        "bloodline_id": 7,
+        "corporation_id": 98785281,
+        "description": "description",
+        "faction_id": null,
+        "gender": "male",
+        "name": "Hyziri",
+        "race_id": 8,
+        "security_status": -0.100373643,
+        "title": "Title",
+    });
 
-    // Configure mock server with an ESI endpoint returning the mock character data
-    let mock = mock_server
+    let mock_character_endpoint = mock_server
         .mock("GET", "/characters/2114794365/")
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(serde_json::to_string(&mock_character).unwrap())
+        .with_body(mock_character.to_string())
         .create();
 
-    // Retrieve the character data
+    let character_id = 2114794365;
     let result = esi_client
         .character()
-        .get_character_public_information(2114794365)
+        .get_character_public_information(character_id)
         .await;
 
-    // Assert 1 request was made to the mock server
-    mock.assert();
+    // Assert 1 request was made to the mock endpoint
+    mock_character_endpoint.assert();
 
-    // Assert result is Ok
     assert!(result.is_ok());
-
-    // Assert received expected character data
-    let character = result.unwrap();
-    assert_eq!(character, mock_character);
 }
 
-/// Tests receiving a 404 error when attempting to retrieve character information from a mock EVE ESI server.
-///
-/// # Test Setup
-/// - Setup a basic EsiClient & mock HTTP server
-/// - Configure mock server with an ESI endpoint returning 404 not found
-///
-/// # Assertions
-/// - Assert 1 request was made to the mock server
-/// - Assert result is error
-/// - Assert reqwest error is due to status NOT_FOUND
+/// Failed retrieval of character information due to 404 not found error
 #[tokio::test]
 async fn get_character_public_information_not_found() {
-    // Setup a basic EsiClient & mock HTTP server
     let (esi_client, mut mock_server) = setup().await;
 
-    // Configure mock server with an ESI endpoint returning 404 not found
-    let mock = mock_server
+    let mock_character_endpoint = mock_server
         .mock("GET", "/characters/2114794365/")
         .with_status(404)
         .with_header("content-type", "application/json")
         .with_body(r#"{"error": "Character not found"}"#)
         .create();
 
-    // Retrieve the character data
+    let character_id = 2114794365;
     let result = esi_client
         .character()
-        .get_character_public_information(2114794365)
+        .get_character_public_information(character_id)
         .await;
 
-    // Assert 1 request was made to the mock server
-    mock.assert();
+    // Assert 1 request was made to the mock endpoint
+    mock_character_endpoint.assert();
 
-    // Assert result is error
     assert!(result.is_err());
-    match result {
-        Err(eve_esi::Error::ReqwestError(err)) => {
-            // Assert reqwest error is due to status NOT_FOUND
-            assert!(err.status().is_some());
-            assert_eq!(err.status().unwrap(), reqwest::StatusCode::NOT_FOUND);
-        }
-        err => {
-            panic!(
-                "Expected ReqwestError, got different error type: {:#?}",
-                err
-            )
-        }
-    }
+
+    assert!(
+        matches!(result, Err(eve_esi::Error::ReqwestError(ref e)) if e.status() == Some(reqwest::StatusCode::NOT_FOUND))
+    );
 }

--- a/tests/endpoints/corporation/get_corporation_information.rs
+++ b/tests/endpoints/corporation/get_corporation_information.rs
@@ -1,111 +1,70 @@
-use eve_esi::model::corporation::Corporation;
-
 use crate::util::setup;
 
-/// Tests the successful retrieval of a corporation from a mock EVE ESI server.
-///
-/// # Test Setup
-/// - Setup a basic EsiClient & mock HTTP server
-/// - Create mock corporation data
-/// - Configure mock server with an ESI endpoint returning the mock corporation
-///
-/// # Assertions
-/// - Assert 1 request was made to the mock server
-/// - Assert result is Ok
-/// - Assert received expected corporation data
+/// Successful retrieval of corporation information
 #[tokio::test]
 async fn get_corporation() {
-    // Setup a basic EsiClient & mock HTTP server
     let (esi_client, mut mock_server) = setup().await;
 
-    // Create mock corporation data
-    let mock_corporation = Corporation {
-        alliance_id: Some(99013534),
-        ceo_id: 2114794365,
-        creator_id: 2114794365,
-        date_founded: Some("2024-10-07T21:43:09Z".parse().unwrap()),
-        description: Some("".to_string()),
-        home_station_id: Some(60003760),
-        member_count: 21,
-        name: "The Order of Autumn".to_string(),
-        shares: Some(1000),
-        tax_rate: 0.0,
-        ticker: "F4LL.".to_string(),
-        url: Some("https://autumn-order.com".to_string()),
-        war_eligible: Some(true),
-        faction_id: None,
-    };
+    let mock_corporation = serde_json::json!({
+        "alliance_id": 99013534,
+        "ceo_id": 2114794365,
+        "creator_id": 2114794365,
+        "date_founded": "2024-10-07T21:43:09Z",
+        "description": "",
+        "home_station_id": 60003760,
+        "member_count": 21,
+        "name": "The Order of Autumn",
+        "shares": 1000,
+        "tax_rate": 0.0,
+        "ticker": "F4LL.",
+        "url": "https://autumn-order.com",
+        "war_eligible": true,
+        "faction_id": null,
+    });
 
-    // Configure mock server with an ESI endpoint returning the mock corporation data
-    let mock = mock_server
+    let mock_corporation_endpoint = mock_server
         .mock("GET", "/corporations/98785281/")
         .with_status(200)
         .with_header("content-type", "application/json")
         .with_body(serde_json::to_string(&mock_corporation).unwrap())
         .create();
 
-    // Retrieve the corporation data
+    let corporation_id = 98785281;
     let result = esi_client
         .corporation()
-        .get_corporation_information(98785281)
+        .get_corporation_information(corporation_id)
         .await;
 
-    // Assert 1 request was made to the mock server
-    mock.assert();
+    // Assert 1 request was made to the mock endpoint
+    mock_corporation_endpoint.assert();
 
-    // Assert result is Ok
     assert!(result.is_ok());
-
-    // Assert received expected corporation data
-    let corporation = result.unwrap();
-    assert_eq!(corporation, mock_corporation);
 }
 
-/// Tests the failed retrieval of corporation due to a 404 not found error.
-///
-/// # Test Setup
-/// - Setup a basic EsiClient & mock HTTP server
-/// - Configure mock server with an ESI endpoint returning 404 not found
-///
-/// # Assertions
-/// - Assert 1 request was made to the mock server
-/// - Assert result is error
-/// - Assert reqwest error is due to status NOT_FOUND
+/// Failed retrieval of corporation due to a 404 not found error.
 #[tokio::test]
 async fn get_corporation_not_found() {
-    // Setup a basic EsiClient & mock HTTP server
     let (esi_client, mut mock_server) = setup().await;
 
-    // Configure mock server with an ESI endpoint returning 404 not found
-    let mock = mock_server
+    let mock_corporation_endpoint = mock_server
         .mock("GET", "/corporations/99999999/")
         .with_status(404)
         .with_header("content-type", "application/json")
         .with_body(r#"{"error": "Corporation not found"}"#)
         .create();
 
-    // Retrieve the corporation data
+    let corporation_id = 99999999;
     let result = esi_client
         .corporation()
-        .get_corporation_information(99999999)
+        .get_corporation_information(corporation_id)
         .await;
 
-    // Assert 1 request was made to the mock server
-    mock.assert();
+    // Assert 1 request was made to the mock endpoint
+    mock_corporation_endpoint.assert();
 
-    // Assert result is error
     assert!(result.is_err());
-    match result {
-        Err(eve_esi::Error::ReqwestError(err)) => {
-            // Assert reqwest error is due to status NOT_FOUND
-            assert!(err.status().is_some());
-            assert_eq!(err.status().unwrap(), reqwest::StatusCode::NOT_FOUND);
-        }
-        err => {
-            panic!(
-                "Expected ReqwestError, got different error type: {:#?}",
-                err
-            )
-        }
-    }
+
+    assert!(
+        matches!(result, Err(eve_esi::Error::ReqwestError(ref e)) if e.status() == Some(reqwest::StatusCode::NOT_FOUND))
+    );
 }


### PR DESCRIPTION
Use `serde_json` to create a body in JSON format for mock ESI endpoints in integration tests. This helps to ensure deserialization of JSON into the ESI models defined by this crate work as expected.

The following integration tests have been modified:
- Character endpoints
- Corporation endpoints
- Alliance Endpoints

Additionally have renamed variables for these tests for better readability as well as stripped out redundant code comments per new code direction of writing code that is more readable and self-explanatory while shifting away from having inline comments on practically every line. See #25 
