### PR TITLE
Rename integration test setup & authenticated endpoints setup

### DIFF
--- a/tests/endpoints/alliance/get_alliance_icon.rs
+++ b/tests/endpoints/alliance/get_alliance_icon.rs
@@ -1,9 +1,9 @@
-use crate::util::setup;
+use crate::util::integration_test_setup;
 
 /// Successful retrieval of alliance icons
 #[tokio::test]
 async fn test_get_alliance_icon_success() {
-    let (esi_client, mut mock_server) = setup().await;
+    let (esi_client, mut mock_server) = integration_test_setup().await;
 
     let mock_alliance_icons = serde_json::json!({
         "px128x128": "ABCD",
@@ -28,7 +28,7 @@ async fn test_get_alliance_icon_success() {
 /// Receiving an error 404 when attempting to retrieve alliance icons
 #[tokio::test]
 async fn test_get_alliance_icon_not_found() {
-    let (esi_client, mut mock_server) = setup().await;
+    let (esi_client, mut mock_server) = integration_test_setup().await;
 
     let mock_icons_endpoint = mock_server
         .mock("GET", "/alliances/99013534/icons")

--- a/tests/endpoints/alliance/get_alliance_information.rs
+++ b/tests/endpoints/alliance/get_alliance_information.rs
@@ -1,9 +1,9 @@
-use crate::util::setup;
+use crate::util::integration_test_setup;
 
 /// Successful retrieval of alliance information
 #[tokio::test]
 async fn get_alliance_information() {
-    let (esi_client, mut mock_server) = setup().await;
+    let (esi_client, mut mock_server) = integration_test_setup().await;
 
     let mock_alliance = serde_json::json!({
         "creator_corporation_id": 98784257,
@@ -36,7 +36,7 @@ async fn get_alliance_information() {
 /// Receiving a 404 error when attempting to retrieve alliance information
 #[tokio::test]
 async fn get_alliance_information_not_found() {
-    let (esi_client, mut mock_server) = setup().await;
+    let (esi_client, mut mock_server) = integration_test_setup().await;
 
     let mock_alliance_endpoint = mock_server
         .mock("GET", "/alliances/99999999/")

--- a/tests/endpoints/alliance/list_all_alliances.rs
+++ b/tests/endpoints/alliance/list_all_alliances.rs
@@ -1,9 +1,9 @@
-use crate::util::setup;
+use crate::util::integration_test_setup;
 
 /// Successful retrieval of list of alliance IDs
 #[tokio::test]
 async fn test_list_all_alliances_success() {
-    let (esi_client, mut mock_server) = setup().await;
+    let (esi_client, mut mock_server) = integration_test_setup().await;
 
     let mock_alliance_ids = serde_json::json!([1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
@@ -25,7 +25,7 @@ async fn test_list_all_alliances_success() {
 /// Receiving an error 500 when calling list_all_alliances()
 #[tokio::test]
 async fn test_list_all_alliances_internal_error() {
-    let (esi_client, mut mock_server) = setup().await;
+    let (esi_client, mut mock_server) = integration_test_setup().await;
 
     let mock = mock_server
         .mock("GET", "/alliances")

--- a/tests/endpoints/alliance/list_alliance_corporations.rs
+++ b/tests/endpoints/alliance/list_alliance_corporations.rs
@@ -1,9 +1,9 @@
-use crate::util::setup;
+use crate::util::integration_test_setup;
 
 /// Successful retrieval of IDs of corporations part of an alliance
 #[tokio::test]
 async fn test_list_alliance_corporations_success() {
-    let (esi_client, mut mock_server) = setup().await;
+    let (esi_client, mut mock_server) = integration_test_setup().await;
 
     let mock_alliance_corporation_ids = serde_json::json!([1, 2, 3, 4, 5, 6, 7, 8, 9]);
 
@@ -29,7 +29,7 @@ async fn test_list_alliance_corporations_success() {
 /// Receiving an error 404 when calling list_alliance_corporations()
 #[tokio::test]
 async fn test_list_alliance_corporations_not_found() {
-    let (esi_client, mut mock_server) = setup().await;
+    let (esi_client, mut mock_server) = integration_test_setup().await;
 
     let mock_alliance_corporations_endpoint = mock_server
         .mock("GET", "/alliances/99013534/corporations")

--- a/tests/endpoints/character/character_affiliation.rs
+++ b/tests/endpoints/character/character_affiliation.rs
@@ -1,9 +1,9 @@
-use crate::util::setup;
+use crate::util::integration_test_setup;
 
 /// Successful retrieval of character affiliations
 #[tokio::test]
 async fn character_affiliation() {
-    let (esi_client, mut mock_server) = setup().await;
+    let (esi_client, mut mock_server) = integration_test_setup().await;
 
     let mock_character_affiliations = serde_json::json!([
         {
@@ -42,7 +42,7 @@ async fn character_affiliation() {
 /// Failed retrieval of character affiliations due to a bad request error
 #[tokio::test]
 async fn character_affiliation_bad_request() {
-    let (esi_client, mut mock_server) = setup().await;
+    let (esi_client, mut mock_server) = integration_test_setup().await;
 
     let mock_character_affiliations_endpoint = mock_server
         .mock("POST", "/characters/affiliation/")

--- a/tests/endpoints/character/get_agents_research.rs
+++ b/tests/endpoints/character/get_agents_research.rs
@@ -2,6 +2,7 @@ use eve_esi::{model::oauth2::EveJwtClaims, oauth2::scope::CharacterScopes, Scope
 use oauth2::TokenResponse;
 
 use crate::{
+    endpoints::util::{authenticated_endpoint_test_setup, mock_access_token_with_scopes},
     oauth2::util::{jwk_response::get_jwk_success_response, jwt::create_mock_token_with_claims},
     util::setup,
 };
@@ -9,7 +10,13 @@ use crate::{
 /// Successful retrieval of character research agents
 #[tokio::test]
 async fn test_get_agents_research_success() {
-    let (esi_client, mut mock_server) = setup().await;
+    let (esi_client, mut mock_server, mock_jwt_key_endpoint) =
+        authenticated_endpoint_test_setup().await;
+    let access_token = mock_access_token_with_scopes(
+        ScopeBuilder::new()
+            .character(CharacterScopes::new().read_agents_research())
+            .build(),
+    );
 
     let mock_research_agents = serde_json::json!([{
         "agent_id": 100,
@@ -18,17 +25,6 @@ async fn test_get_agents_research_success() {
         "skill_type_id": 100,
         "started_at": "2018-12-20T16:11:54Z",
     }]);
-
-    let mut mock_access_token_claims = EveJwtClaims::mock();
-    mock_access_token_claims.scp = ScopeBuilder::new()
-        .character(CharacterScopes::new().read_agents_research())
-        .build();
-    let token = create_mock_token_with_claims(false, mock_access_token_claims);
-
-    let access_token = token.access_token().secret().to_string();
-
-    // Create JWT key endpoint for token validation before request
-    let mock_jwt_key_endpoint = get_jwk_success_response(&mut mock_server, 1);
 
     let mock_research_agents_endpoint = mock_server
         .mock("GET", "/characters/2114794365/agents_research")

--- a/tests/endpoints/character/get_agents_research.rs
+++ b/tests/endpoints/character/get_agents_research.rs
@@ -4,7 +4,7 @@ use oauth2::TokenResponse;
 use crate::{
     endpoints::util::{authenticated_endpoint_test_setup, mock_access_token_with_scopes},
     oauth2::util::{jwk_response::get_jwk_success_response, jwt::create_mock_token_with_claims},
-    util::setup,
+    util::integration_test_setup,
 };
 
 /// Successful retrieval of character research agents
@@ -53,7 +53,7 @@ async fn test_get_agents_research_success() {
 /// Failed retrieval of character affiliations due to an internal server error
 #[tokio::test]
 async fn test_get_agents_research_500_internal_error() {
-    let (esi_client, mut mock_server) = setup().await;
+    let (esi_client, mut mock_server) = integration_test_setup().await;
 
     let mut mock_access_token_claims = EveJwtClaims::mock();
     mock_access_token_claims.scp = ScopeBuilder::new()

--- a/tests/endpoints/character/get_character_public_information.rs
+++ b/tests/endpoints/character/get_character_public_information.rs
@@ -1,9 +1,9 @@
-use crate::util::setup;
+use crate::util::integration_test_setup;
 
 /// Tests the successful retrieval of character information from a mock EVE ESI server.
 #[tokio::test]
 async fn get_character_public_information() {
-    let (esi_client, mut mock_server) = setup().await;
+    let (esi_client, mut mock_server) = integration_test_setup().await;
 
     let mock_character = serde_json::json!({
         "alliance_id": 99013534,
@@ -41,7 +41,7 @@ async fn get_character_public_information() {
 /// Failed retrieval of character information due to 404 not found error
 #[tokio::test]
 async fn get_character_public_information_not_found() {
-    let (esi_client, mut mock_server) = setup().await;
+    let (esi_client, mut mock_server) = integration_test_setup().await;
 
     let mock_character_endpoint = mock_server
         .mock("GET", "/characters/2114794365/")

--- a/tests/endpoints/corporation/get_corporation_information.rs
+++ b/tests/endpoints/corporation/get_corporation_information.rs
@@ -1,9 +1,9 @@
-use crate::util::setup;
+use crate::util::integration_test_setup;
 
 /// Successful retrieval of corporation information
 #[tokio::test]
 async fn get_corporation() {
-    let (esi_client, mut mock_server) = setup().await;
+    let (esi_client, mut mock_server) = integration_test_setup().await;
 
     let mock_corporation = serde_json::json!({
         "alliance_id": 99013534,
@@ -44,7 +44,7 @@ async fn get_corporation() {
 /// Failed retrieval of corporation due to a 404 not found error.
 #[tokio::test]
 async fn get_corporation_not_found() {
-    let (esi_client, mut mock_server) = setup().await;
+    let (esi_client, mut mock_server) = integration_test_setup().await;
 
     let mock_corporation_endpoint = mock_server
         .mock("GET", "/corporations/99999999/")

--- a/tests/endpoints/mod.rs
+++ b/tests/endpoints/mod.rs
@@ -1,3 +1,4 @@
 mod alliance;
 mod character;
 mod corporation;
+mod util;

--- a/tests/endpoints/util.rs
+++ b/tests/endpoints/util.rs
@@ -1,0 +1,28 @@
+use eve_esi::model::oauth2::EveJwtClaims;
+use mockito::{Mock, ServerGuard};
+use oauth2::TokenResponse;
+
+use crate::{
+    oauth2::util::{jwk_response::get_jwk_success_response, jwt::create_mock_token_with_claims},
+    util::setup,
+};
+
+/// Utility to setup JWT key endpoint for validation to test authenticated ESI routes
+pub(super) async fn authenticated_endpoint_test_setup() -> (eve_esi::Client, ServerGuard, Mock) {
+    let (esi_client, mut mock_server) = setup().await;
+
+    // Create JWT key endpoint for token validation before request
+    let mock_jwt_key_endpoint = get_jwk_success_response(&mut mock_server, 1);
+
+    (esi_client, mock_server, mock_jwt_key_endpoint)
+}
+
+/// Utility to create an access token for authenticated ESI routes
+pub(super) fn mock_access_token_with_scopes(scopes: Vec<String>) -> String {
+    let mut mock_access_token_claims = EveJwtClaims::mock();
+    mock_access_token_claims.scp = scopes;
+
+    let token = create_mock_token_with_claims(false, mock_access_token_claims);
+
+    token.access_token().secret().to_string()
+}

--- a/tests/endpoints/util.rs
+++ b/tests/endpoints/util.rs
@@ -4,12 +4,12 @@ use oauth2::TokenResponse;
 
 use crate::{
     oauth2::util::{jwk_response::get_jwk_success_response, jwt::create_mock_token_with_claims},
-    util::setup,
+    util::integration_test_setup,
 };
 
 /// Utility to setup JWT key endpoint for validation to test authenticated ESI routes
 pub(super) async fn authenticated_endpoint_test_setup() -> (eve_esi::Client, ServerGuard, Mock) {
-    let (esi_client, mut mock_server) = setup().await;
+    let (esi_client, mut mock_server) = integration_test_setup().await;
 
     // Create JWT key endpoint for token validation before request
     let mock_jwt_key_endpoint = get_jwk_success_response(&mut mock_server, 1);

--- a/tests/esi/validate_token_before_request.rs
+++ b/tests/esi/validate_token_before_request.rs
@@ -2,12 +2,12 @@ use oauth2::TokenResponse;
 
 use crate::oauth2::util::jwk_response::get_jwk_success_response;
 use crate::oauth2::util::jwt::create_mock_token;
-use crate::util::setup;
+use crate::util::integration_test_setup;
 
 /// No validation will be made due to ESI client config diabling it
 #[tokio::test]
 async fn test_validate_token_before_request_disabled() {
-    let (_, mut mock_server) = setup().await;
+    let (_, mut mock_server) = integration_test_setup().await;
 
     let config = eve_esi::Config::builder()
         .esi_validate_token_before_request(false)

--- a/tests/oauth2/jwk/fetch_and_update_cache.rs
+++ b/tests/oauth2/jwk/fetch_and_update_cache.rs
@@ -1,7 +1,7 @@
 use crate::oauth2::util::jwk_response::{
     get_jwk_internal_server_error_response, get_jwk_success_response,
 };
-use crate::util::setup;
+use crate::util::integration_test_setup;
 
 /// Tests that JWK keys are properly fetched & cache is updated
 ///
@@ -14,7 +14,7 @@ use crate::util::setup;
 #[tokio::test]
 async fn test_fetch_and_update_cache_success() {
     // Setup a basic EsiClient & mock HTTP server
-    let (esi_client, mut mock_server) = setup().await;
+    let (esi_client, mut mock_server) = integration_test_setup().await;
 
     // Create mock response with mock keys & expecting 1 request
     let mock = get_jwk_success_response(&mut mock_server, 1);
@@ -42,7 +42,7 @@ async fn test_fetch_and_update_cache_success() {
 #[tokio::test]
 async fn test_fetch_and_update_cache_request_error() {
     // Setup a basic EsiClient & mock HTTP server
-    let (esi_client, mut mock_server) = setup().await;
+    let (esi_client, mut mock_server) = integration_test_setup().await;
 
     // Create mock response with error 500 and expecting 1 request
     let mock = get_jwk_internal_server_error_response(&mut mock_server, 1);

--- a/tests/oauth2/jwk/fetch_jwt_keys.rs
+++ b/tests/oauth2/jwk/fetch_jwt_keys.rs
@@ -3,7 +3,7 @@ use eve_esi::model::oauth2::EveJwtKey;
 use crate::oauth2::util::jwk_response::{
     get_jwk_internal_server_error_response, get_jwk_success_response,
 };
-use crate::util::setup;
+use crate::util::integration_test_setup;
 
 /// Tests the successful retrieval of JWT keys from a mock EVE SSO server.
 ///
@@ -19,7 +19,7 @@ use crate::util::setup;
 #[tokio::test]
 async fn fetch_jwt_keys_success() {
     // Setup a basic Client & mock HTTP server
-    let (esi_client, mut mock_server) = setup().await;
+    let (esi_client, mut mock_server) = integration_test_setup().await;
 
     // Create mock response with mock keys & expecting 1 request
     let mock = get_jwk_success_response(&mut mock_server, 1);
@@ -67,7 +67,7 @@ async fn fetch_jwt_keys_success() {
 #[tokio::test]
 async fn fetch_jwt_keys_server_error() {
     // Setup a basic Client & mock HTTP server
-    let (esi_client, mut mock_server) = setup().await;
+    let (esi_client, mut mock_server) = integration_test_setup().await;
 
     // Create mock response with error 500 and expecting 1 request
     let mock = get_jwk_internal_server_error_response(&mut mock_server, 1);
@@ -163,7 +163,7 @@ async fn fetch_jwt_keys_network_error() {
 #[tokio::test]
 async fn fetch_jwt_keys_parse_error() {
     // Setup a basic Client & mock HTTP server
-    let (esi_client, mut mock_server) = setup().await;
+    let (esi_client, mut mock_server) = integration_test_setup().await;
 
     // Create mock success response with unexpected body
     let mock = mock_server

--- a/tests/oauth2/jwk/get_jwt_keys.rs
+++ b/tests/oauth2/jwk/get_jwt_keys.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use crate::oauth2::util::jwk_response::{
     get_jwk_internal_server_error_response, get_jwk_success_response,
 };
-use crate::util::setup;
+use crate::util::integration_test_setup;
 
 /// Tests that get_jwt_keys returns cached keys when they are not expired.
 ///
@@ -19,7 +19,7 @@ use crate::util::setup;
 #[tokio::test]
 async fn get_jwt_keys_valid_cache() {
     // Setup a basic EsiClient & mock HTTP server
-    let (esi_client, mut mock_server) = setup().await;
+    let (esi_client, mut mock_server) = integration_test_setup().await;
 
     // Create a mock response expecting 1 request for initial cache population
     let mock = get_jwk_success_response(&mut mock_server, 1);
@@ -55,7 +55,7 @@ async fn get_jwt_keys_valid_cache() {
 #[tokio::test]
 async fn get_jwt_keys_expired_cache() {
     // Setup a basic EsiClient & mock HTTP server
-    let (esi_client, mut mock_server) = setup().await;
+    let (esi_client, mut mock_server) = integration_test_setup().await;
 
     // Create mock success response expecting 2 requests:
     // - Pre-populating the cache
@@ -100,7 +100,7 @@ async fn get_jwt_keys_expired_cache() {
 #[tokio::test]
 async fn get_jwt_keys_empty_cache() {
     // Setup a basic EsiClient & mock HTTP server
-    let (esi_client, mut mock_server) = setup().await;
+    let (esi_client, mut mock_server) = integration_test_setup().await;
 
     // Create mock response with mock keys & expecting 1 request
     let mock = get_jwk_success_response(&mut mock_server, 1);
@@ -135,7 +135,7 @@ async fn get_jwt_keys_empty_cache() {
 #[tokio::test]
 async fn get_jwt_keys_refresh_cooldown() {
     // Setup a basic EsiClient & mock HTTP server
-    let (esi_client, mut mock_server) = setup().await;
+    let (esi_client, mut mock_server) = integration_test_setup().await;
 
     // Create a mock response expecting 3 requests
     let mock = get_jwk_internal_server_error_response(&mut mock_server, 3);
@@ -183,7 +183,7 @@ async fn get_jwt_keys_refresh_cooldown() {
 #[tokio::test]
 async fn get_jwt_keys_background_refresh() {
     // Setup a basic EsiClient & mock HTTP server
-    let (esi_client, mut mock_server) = setup().await;
+    let (esi_client, mut mock_server) = integration_test_setup().await;
 
     // Create a mock response expecting 2 requests:
     // - Pre-populate the cache
@@ -238,7 +238,7 @@ async fn get_jwt_keys_background_refresh() {
 #[tokio::test]
 async fn get_jwt_keys_concurrency() {
     // Setup a basic EsiClient & mock HTTP server
-    let (esi_client, mut mock_server) = setup().await;
+    let (esi_client, mut mock_server) = integration_test_setup().await;
 
     // Create a mock response expecting 1 request
     let mock = get_jwk_success_response(&mut mock_server, 1);

--- a/tests/oauth2/token/get_token.rs
+++ b/tests/oauth2/token/get_token.rs
@@ -2,7 +2,7 @@ use oauth2::RequestTokenError;
 
 use crate::{
     oauth2::token::util::{get_token_bad_request_response, get_token_success_response},
-    util::setup,
+    util::integration_test_setup,
 };
 
 /// Tests the successful retrieval of a JWT token
@@ -17,7 +17,7 @@ use crate::{
 #[tokio::test]
 pub async fn test_get_token_success() {
     // Create Client configured with OAuth2 & mock server
-    let (client, mut mock_server) = setup().await;
+    let (client, mut mock_server) = integration_test_setup().await;
 
     // Create mock response with 200 success response & mock token
     let mock = get_token_success_response(&mut mock_server, 1);
@@ -45,7 +45,7 @@ pub async fn test_get_token_success() {
 #[tokio::test]
 pub async fn test_get_token_error() {
     // Create Client configured with OAuth2 & mock server
-    let (client, mut mock_server) = setup().await;
+    let (client, mut mock_server) = integration_test_setup().await;
 
     // Create mock response returning a 400 bad request
     let mock = get_token_bad_request_response(&mut mock_server, 1);
@@ -68,7 +68,7 @@ pub async fn test_get_token_error() {
     ));
 }
 
-/// Returns an error if OAuth2 is not setup on ESI client
+/// Returns an error if OAuth2 is not integration_test_setup on ESI client
 ///
 /// # Setup
 /// - Create an ESI client without OAuth2 configured
@@ -80,7 +80,7 @@ pub async fn test_get_token_error() {
 /// - Assert error is of type OAuthError::OAuth2NotConfigured
 #[tokio::test]
 pub async fn test_get_token_oauth_client_missing() {
-    let (_, mut mock_server) = setup().await;
+    let (_, mut mock_server) = integration_test_setup().await;
 
     // Create ESI client without OAuth2 config & with mock token endpoint
     let config = eve_esi::Config::builder()

--- a/tests/oauth2/token/get_token_refresh.rs
+++ b/tests/oauth2/token/get_token_refresh.rs
@@ -5,7 +5,7 @@ use crate::{
         token::util::{get_token_bad_request_response, get_token_success_response},
         util::jwt::create_mock_token,
     },
-    util::setup,
+    util::integration_test_setup,
 };
 
 /// Tests the successful refresh of a JWT token
@@ -21,7 +21,7 @@ use crate::{
 #[tokio::test]
 pub async fn test_get_token_refresh_success() {
     // Create Client configured with OAuth2 & mock server
-    let (client, mut mock_server) = setup().await;
+    let (client, mut mock_server) = integration_test_setup().await;
 
     // Create mock response with 200 success response & mock token
     let mock = get_token_success_response(&mut mock_server, 1);
@@ -54,7 +54,7 @@ pub async fn test_get_token_refresh_success() {
 #[tokio::test]
 pub async fn test_get_token_refresh_error() {
     // Create Client configured with OAuth2 & mock server
-    let (client, mut mock_server) = setup().await;
+    let (client, mut mock_server) = integration_test_setup().await;
 
     // Create mock response returning a 400 bad request
     let mock = get_token_bad_request_response(&mut mock_server, 1);
@@ -82,7 +82,7 @@ pub async fn test_get_token_refresh_error() {
     ));
 }
 
-/// Returns an error if OAuth2 is not setup on ESI client
+/// Returns an error if OAuth2 is not integration_test_setup on ESI client
 ///
 /// # Setup
 /// - Create an ESI client without OAuth2 configured
@@ -95,7 +95,7 @@ pub async fn test_get_token_refresh_error() {
 /// - Assert error is of type OAuthError::OAuth2NotConfigured
 #[tokio::test]
 pub async fn test_get_token_refresh_oauth_client_missing() {
-    let (_, mut mock_server) = setup().await;
+    let (_, mut mock_server) = integration_test_setup().await;
 
     // Create ESI client without OAuth2 config & with mock token endpoint
     let config = eve_esi::Config::builder()

--- a/tests/oauth2/token/validate_token.rs
+++ b/tests/oauth2/token/validate_token.rs
@@ -8,7 +8,7 @@ use crate::oauth2::util::jwk_response::{
     get_jwk_internal_server_error_response, get_jwk_success_response,
 };
 use crate::oauth2::util::jwt::{create_mock_token, create_mock_token_keys, RSA_KEY_ID};
-use crate::util::setup;
+use crate::util::integration_test_setup;
 
 /// Tests successful validation of a JWT token
 ///
@@ -27,7 +27,7 @@ use crate::util::setup;
 #[tokio::test]
 pub async fn test_validate_token_success() {
     // Create Client configured with OAuth2 & mock server
-    let (client, mut mock_server) = setup().await;
+    let (client, mut mock_server) = integration_test_setup().await;
 
     // Create a mock JWT key response the Client will fetch for the JWT key cache
     let mock = get_jwk_success_response(&mut mock_server, 1);
@@ -78,7 +78,7 @@ pub async fn test_validate_token_success() {
 #[tokio::test]
 async fn test_validate_token_get_jwt_key_failure() {
     // Create Client configured with OAuth2 & mock server
-    let (client, mut mock_server) = setup().await;
+    let (client, mut mock_server) = integration_test_setup().await;
 
     // Create a mock JWT key response that will return an error after 3 attempts
     let mock = get_jwk_internal_server_error_response(&mut mock_server, 3);
@@ -137,7 +137,7 @@ async fn test_validate_token_get_jwt_key_failure() {
 #[tokio::test]
 async fn test_validate_token_no_rs256_key() {
     // Create Client configured with OAuth2 & mock server
-    let (client, mut mock_server) = setup().await;
+    let (client, mut mock_server) = integration_test_setup().await;
 
     // Create a mock EveJwtKeys struct that only contains an ES256 key
     let only_es256_key = EveJwtKeys {
@@ -213,7 +213,7 @@ async fn test_validate_token_no_rs256_key() {
 #[tokio::test]
 async fn test_validate_token_decoding_key_error() {
     // Create Client configured with OAuth2 & mock server
-    let (client, mut mock_server) = setup().await;
+    let (client, mut mock_server) = integration_test_setup().await;
 
     // Create a mock EveJwtKeys struct that only contains a malformed RS256 key (invalid modulus)
     let malformed_rs256 = EveJwtKeys {
@@ -288,7 +288,7 @@ async fn test_validate_token_decoding_key_error() {
 #[tokio::test]
 async fn test_validate_token_validation_error() {
     // Create Client configured with OAuth2 & mock server
-    let (client, mut mock_server) = setup().await;
+    let (client, mut mock_server) = integration_test_setup().await;
 
     // Create a mock JWT key response the Client will fetch for the JWT key cache
     let mock = get_jwk_success_response(&mut mock_server, 1);
@@ -352,7 +352,7 @@ async fn test_validate_token_validation_error() {
 #[tokio::test]
 async fn test_validate_token_key_rotation() {
     // Create Client configured with no refresh cooldown to immediately clear & refresh cache on validation failure
-    let (_, mut mock_server) = setup().await;
+    let (_, mut mock_server) = integration_test_setup().await;
 
     let config = eve_esi::Config::builder()
         // Set endpoint to mock server

--- a/tests/util/mod.rs
+++ b/tests/util/mod.rs
@@ -1,3 +1,3 @@
 mod setup;
 
-pub use setup::setup;
+pub use setup::integration_test_setup;

--- a/tests/util/setup.rs
+++ b/tests/util/setup.rs
@@ -15,7 +15,7 @@ use crate::constant::TEST_CLIENT_ID;
 /// A tuple containing:
 /// - [`eve_esi::Client`]: A basic Client with jwk_url set to the mock server
 /// - [`mockito::ServerGuard`]: A mock server for handling http requests for test purposes
-pub async fn setup() -> (eve_esi::Client, ServerGuard) {
+pub async fn integration_test_setup() -> (eve_esi::Client, ServerGuard) {
     // Setup mock server
     let mock_server = Server::new_async().await;
     let mock_server_url = mock_server.url();


### PR DESCRIPTION
Renamed the `setup()` utility function for integration tests to a less ambiguous name: `integration_test_setup()`

Added a utility functions to setup the requirements for authenticated ESI endpoint integration tests:
- `authenticated_endpoint_test_setup`: Calls `integration_test_setup` and adds a JWT key endpoint for the token validation that is done prior to every authenticated ESI request using an access token.
- `mock_access_token_with_scopes`: Returns a mock access token in string format with the required scopes for an authenticated ESI request

I've considered disabling the token validation before each authenticated ESI request for integration tests as there is an option to do so in config but I determined it would be best to keep it as if it were to break for any reason it would cause all authenticated endpoint integration tests to fail. I feel as if this is important to reflect how critical this function is and the urgency of a fix should any issues arise.