### PR TITLE
Update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,90 @@
 # EVE ESI
 
+> [!WARNING]
+>
+> **This crate is still under development, APIs may change between versions**
+>
+> Currently the crate features OAuth2 login with EVE Online and we're now currently working on implementing all ESI endpoints. The goal is to implement an average of around 10 endpoints per day, it takes about 15 minutes to implement each endpoint due to writing related structs, enums, documentation & integration tests. All endpoints are expected to be added around early October at this rate.
+>
+> Documentation for this crate is still work-in-progress, if you see any issues or areas for improvement in documentation contributions are always welcome to help make this crate more accessible to other developers.
+
 [![Crates.io Version](https://img.shields.io/crates/v/eve_esi?logo=rust)](https://crates.io/crates/eve_esi/)
 [![codecov](https://codecov.io/gh/hyziri/eve_esi/graph/badge.svg?token=OXD57P1UY6)](https://codecov.io/gh/hyziri/eve_esi)
 [![Maintainability](https://qlty.sh/gh/hyziri/projects/eve_esi/maintainability.svg)](https://qlty.sh/gh/hyziri/projects/eve_esi)
+[![wakatime](https://wakatime.com/badge/github/hyziri/eve_esi.svg)](https://wakatime.com/badge/github/hyziri/eve_esi)
+[![Discord](https://img.shields.io/discord/1414000815017824288?logo=Discord&color=%235865F2)](https://discord.gg/HjaGsBBtFg)
 
 A thread-safe, asynchronous client which provides methods & types for interaction with [EVE Online's ESI](https://developers.eveonline.com/api-explorer) & [EVE Online's single sign-on (SSO)](https://developers.eveonline.com/docs/services/sso/).
 
-This crate implements concurrency & caching to provide performance in applications at scale. For example JSON web token keys (JWT keys) are used to validate tokens after a successful EVE Online single sign-on login, this crate automatically caches the keys and refreshes them proactively before expiry in a background task for mimimal latency.
+**Documentation:** https://docs.rs/eve_esi/latest/eve_esi/
 
-This crate is still heavily under development and has yet to implement the majority of ESI routes.
+**Contributing:** https://github.com/hyziri/eve_esi/blob/main/CONTRIBUTING.md
 
-## Usage
+**Discord:** https://discord.gg/HjaGsBBtFg
+
+For usage examples, ESI client configuration, and logging configuration, please see the [documentation](https://docs.rs/eve_esi/latest/eve_esi/)
+
+Have questions about this crate or EVE Online's ESI in general? Ask us in [Discord](https://discord.gg/HjaGsBBtFg)!
+
+## Features
+
+**EVE Online Single Sign-On**
+
+EVE Online's single sign-on (OAuth2) login flow has been fully implemented in the crate featuring:
+
+- Configuring of an EVE ESI client with an EVE Online developer application client id, client secret, and callback URL
+- Creation of login URLs to begin the OAuth2 login flow
+- The fetching, caching, & proactive refreshing of JWT token keys used to validate access tokens
+- Access token fetching, validation, & refreshing
+
+**EVE Online ESI Endpoints**
+
+The implementation of ESI endpoints within this crate is still ongoing, we are aiming for all to be added by early October. So far the following 3 [ESI API Explorer](https://developers.eveonline.com/api-explorer) categories have been implemented:
+
+- Character endpoints
+- Corporation endpoints
+- Alliance endpoints
+
+Going forward a new version of this crate will be released with the implementation of a new category up until version 0.5.0 which indicates all endpoints have been added.
+
+**Thread-safe**
+
+This crate implements the usage of read/write locks, compare exchanges, atomic bools, & tokio notifiers to provide performance in applications at scale.
+
+- **Refresh Locks:** The usage of atomic bools allows for the acquisition of a refresh lock on the JWT token key cache used to validate access tokens so that only 1 thread actually performs the cache refresh
+- **High Concurrency:** The refresh lock is acquired via a compare exchange which is performance efficient in high concurrency applications where dozens of worker threads may attempt to acquire this refresh lock at once
+- **Refresh Notifications:** While the refresh lock is in progress and the cache is currently expired or empty meaning no keys are available for validation, threads will wait for a tokio notifier notification that the refresh has completed. This makes it so that threads wait no longer than necessary for a completed refresh.
+- **Read/Write Locks:** The JWT key cache utilizes read/write locks for minimal performance impact when accessing the JWT keys in the cache across multiple threads
+
+The ESI client provided by this crate by default is wrapped within an Arc (atomic reference counter) which allows for the ESI client to be safely shared across threads.
+
+- **Asynchronous:** This crate utilizes Rust ecosystem tools such as [Reqwest](https://crates.io/crates/reqwest) & [Tokio](https://crates.io/crates/tokio) to make ESI requests asynchronously and with minimal latency.
+
+- **Caching:** Caching is utilized where possible to do to mimize latency with the OAuth2 login flow for EVE Online, the JWT token keys used to validate access tokens are cached for up to one hour and refreshed proactively before expiration to avoid any delay when validating tokens.
+
+- **Type-Safe:** In addition to Rust's strong type safety, this crate additionally defines enums for ESI models in every area where it is applicable & possible to do so to make clear what exactly one can expect from ESI responses.
+
+- **Documentation:** The endpoints, models, & enums within this crate are all documented to help clarify what certain fields or enum variants are for, making it more accessible to developers unfamiliar with some areas of the game. Even the 250~ variants of the `NotificationType` enum have documentation.
+
+- **Testing:** All functions are unit tested and all endpoints implemented within this crate are integration tested to ensure proper error responses, handling of parameters & URLs, and deserialization of ESI JSON responses to the models defined within this crate.
+
+- **Logging:** All functions & endpoints integrate the usage of the [log crate](https://crates.io/crates/log) to provide insight to the inner workings of this crate at runtime and help narrow down the source of any issues that may occur. Logging is configurable and opt-in, from detailed trace logging to only essential info logging.
+
+- **Configuration:** The ESI client provided by this crate is configurable, from a basic client with only a user agent for public ESI to a client for OAuth2 to fine-tuning the inner workings of the client such as the parameters & timings of how JWT tokens are cached and refreshed
+
+## Usage Example
 
 Create a new ESI Client instance and request public information about a corporation from ESI.
 
 ```rust
 // esi_client is asynchronous, #[tokio::main] allows for making the main function async
-// You would ideally use esi_client with an async web framework like Axum as shown in examples
 #[tokio::main]
 async fn main() {
     // Set a user_agent to identify your application when making requests
     let user_agent = "MyApp/1.0 (contact@example.com; +https://github.com/your/repository)";
 
     // Create a basic ESI client with user_agent
-    let esi_client = eve_esi::Client::new(user_agent).expect("Failed to build Client");
+    let esi_client = eve_esi::Client::new(user_agent).expect("Failed to build ESI Client");
 
     // Get information about the corporation The Order of Autumn (id: 98785281)
     let corporation = esi_client.corporation().get_corporation_information(98785281).await.unwrap();
@@ -32,129 +93,7 @@ async fn main() {
 }
 ```
 
-## Quickstart
-
-### Building a Client
-
-You can build an ESI client with the builder method:
-
-```rust
-let esi_client = eve_esi::Client::builder()
-  // Always set a user agent to identify your application
-  .user_agent("MyApp/1.0 (contact@example.com; +https://github.com/your/repository)")
-  // Optional: Set these 3 to configure for single sign-on login & authenticated ESI routes
-  // Get them from https://developers.eveonline.com/applications
-  .client_id("client_id")
-  .client_secret("client_secret")
-  .callback_url("http://localhost:8080/callback") // This would be an API endpoint on your app, see SSO example
-  .build()
-  .expect("Failed to build ESI Client");
-```
-
-For ideal performance, if you are already using a `reqwest::Client` in your application you should `.clone()` it when building an `eve_esi::Client` to share the same HTTP pool rather than `eve_esi::Client` using its own `reqwest::Client` by default:
-
-```rust
-let esi_client = eve_esi::Client::builder()
-  .reqwest_client(reqwest_client.clone())
-```
-
-### Making Public ESI Requests
-
-This library mirrors the [EVE ESI API explorer](https://developers.eveonline.com/api-explorer) in that you can access endpoints by the format of:
-
-```rust
-esi_client.category_name().method_name()
-
-// This would translate to:
-let alliances = esi_client.alliance().list_all_alliances()
-```
-
-### OAuth2 (SSO) Login
-
-To access any authenticated ESI routes, your users will first need to sign-in using EVE Online's single-sign on (SSO), also known as OAuth2.
-A complete SSO example can be found at <https://github.com/hyziri/eve_esi/blob/main/examples/sso.rs>.
-
-Anything single sign-on/oauth2 related is accessed with:
-
-```rust
-esi_client.oauth2()
-```
-
-Login route: create a URL to redirect your users for the login process:
-
-```rust
-// Set scopes to request
-let scopes = eve_esi::ScopeBuilder::new()
-  .public_data() // publicData scope
-  .build();
-
-// Create a login URL
-let login = esi_client
-  .oauth2()
-  .login_url(scopes)
-  .expect("Failed to create a login url"); // Errors if OAuth2 is not configured on ESI Client
-
-let login_url = login.login_url; // Redirect users to this URL to begin the login process
-let state = login.state; // State code for preventing CSRF which you should validate in your callback route
-```
-
-Callback route: retrieving a token, getting the access & refresh token:
-
-```rust
-// Use the authorization code present as the {?code=...} query parameter in your callback route URL
-// See https://github.com/hyziri/eve_esi/blob/main/examples/sso.rs for callback route example
-let token = esi_client
-    .oauth2()
-    .get_token(authorization_code)
-    .await
-    .expect("Failed to fetch token");
-
-let access_token = token.access_token();
-let refresh_token = token.refresh_token();
-
-// Refresh token can be converted to a String this way
-let refresh_token_string = refresh_token.unwrap().secret().to_string();
-```
-
-Callback route: validating a token, accessing character ID & name:
-
-```rust
-// Validate the token to access the claims
-let claims = esi_client
-    .oauth2()
-    .validate_token(token.access_token().secret().to_string())
-    .await
-    .expect("Failed to validate token");
-
-// Access character ID & name
-
-// claims.sub looks like a String: "CHARACTER:EVE:2114794365"
-// We'll extract the ID part and convert it to an i32
-let id_str = claims.sub.split(':').collect::<Vec<&str>>()[2];
-
-let character_id: i32 = id_str.parse().expect("Failed to parse id to i32");
-let character_name: String = claims.name;
-```
-
-Refreshing a token:
-
-```rust
-// In this scenario, refresh token was stored in database & retrieved as a string
-let refresh_token = "refresh_token_string...".to_string();
-
-// Call `get_token_refresh` and pass the refresh token string to get a new token
-let token = esi_client
-    .oauth2()
-    .get_token_refresh(refresh_token)
-    .await
-    .expect("Failed to fetch token");
-
-// Validate the token here and replace the old access/refresh token stored in the database...
-```
-
-### Making Authenticated ESI Requests
-
-TODO: Work in progress
+For more usage examples, ESI client configuration, and logging configuration, please see the [documentation](https://docs.rs/eve_esi/latest/eve_esi/)
 
 ## Examples
 
@@ -177,36 +116,4 @@ An example demonstrating how to use the `eve_esi` crate with the `axum` web fram
 4. Run `cargo run --example sso`
 5. Go to `http://localhost:8080/login` in your browser
 6. Login with EVE Online, you'll then be redirected to `http://localhost:8080/callback`
-7. Internally, the callback route will fetch a JWT token using the authorization code from login. The callback response will show your character ID & name.
-
-## Logging
-
-This library uses the [`log`](https://crates.io/crates/log) crate for logging. To capture log output,
-applications using this library should initialize a logger implementation like `env_logger`,
-`simple_logger`, or any other implementation of the `log` crate's facade.
-
-For production, you'll generally want to use log level either `info` or `warn` depending on how much you wish to rely on this crate's logging for your application.
-
-### Log Levels
-
-- **Error**: Used for failures that prevent successful API calls
-- **Warn**: Used for potential issues that don't prevent operation but could be problematic
-- **Info**: Used for successful API calls and important client state changes
-- **Debug**: Used for detailed information about API call parameters and responses
-- **Trace**: Used for very detailed debugging information
-
-### Example with env_logger
-
-```rust
-// Set RUST_LOG environment variable to control log levels
-// e.g., RUST_LOG=eve_esi=debug,info
-
-// Initialize env_logger
-env_logger::init();
-
-// Now logs from eve_esi will be captured
-let esi_client = eve_esi::Client::builder()
-    .user_agent("MyApp/1.0 (contact@example.com; +https://github.com/your/repository)")
-    .build()
-    .expect("Failed to build Client");
-```
+7. The callback route will fetch a JWT token using the authorization code from login and then return a response with your character ID & name after validating the token

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -9,16 +9,17 @@
 //! - [EVE SSO Documentation](https://developers.eveonline.com/docs/services/sso/)
 //!
 //! ## Features
-//! - Set a user agent
+//! - Set a user agent to identify your application's requests
 //! - Configure [`Client`] for OAuth2 using `client_id`, `client_secret`, and `callback_url` methods
+//! - Share a reqwest Client with the ESI client for optimal performance by using the same connection pool
 //! - Override the default JWT key cache & refresh settings used to validate OAuth2 tokens & override
 //!   the default endpoint URLs with a custom [`Config`] using the [`ClientBuilder::config`] method.
 //!
 //! ## Builder Methods
 //! | Method           | Purpose                                 |
 //! | ---------------- | --------------------------------------- |
-//! | `new`            | Create a builder for the Client      |
-//! | `build`          | Build the Client                     |
+//! | `new`            | Create a builder for the Client         |
+//! | `build`          | Build the Client                        |
 //! | `config`         | Override the default config             |
 //! | `reqwest_client` | Override default reqwest client         |
 //! | `user_agent`     | User agent to identify HTTP requests    |
@@ -27,21 +28,37 @@
 //! | `callback_url`   | EVE OAuth2 callback URL                 |
 //!
 //! ## Usage
+//! ### Building an ESI client for OAuth2
+//! **Prerequisites:**
+//! - **EVE Online Developer Application:** First, you will need to get a client ID & client
+//!   secret as well as set the callback URL where your user's will be redirected to after
+//!   login. Setup a developer application at <https://developers.eveonline.com/applications>
+//! - **Set environment variables:** Never hard-code your client ID & client secret, instead
+//!   use a .env file and then load it with the [`dotenvy`](https://crates.io/crates/dotenvy)
+//!   crate as demonstrated in the [SSO example](https://github.com/hyziri/eve_esi/blob/main/examples/sso.rs).
+//!
 //! ```
 //! use eve_esi::Client;
 //!
-//! // Set a user agent used to identify the application making ESI requests
+//! // Always set a user_agent to identify your application when making requests
+//! let user_agent = "MyApp/1.0 (contact@example.com; +https://github.com/your/repository)";
+//!
+//! // Create an ESI client with the builder method to configure OAuth2 settings
 //! let esi_client = Client::builder()
-//!     .user_agent("MyApp/1.0 (contact@example.com; +https://github.com/your/repository)")
+//!     .user_agent(user_agent)
+//!     .client_id("client_id")
+//!     .client_secret("client_secret")
+//!     .callback_url("http://localhost:8080/callback")
 //!     .build()
-//!     .expect("Failed to build Client");
+//!     .expect("Failed to build ESI Client");
 //! ```
 //!
 //! ## Warning
-//! EVE Online's ESI API requires setting a proper user agent. Failure to do so may result in rate limiting or API errors.
-//! Include application name, version, and contact information in your user agent string.
+//! EVE Online requires setting a proper user agent. Failure to do so may result in rate limiting or API errors.
+//! Include application name, version, and contact information in your user agent string as well as the repository
+//! of your application if it is open source.
 //!
-//! Example: `"MyApp/1.0 (contact@example.com; +https://github.com/your/repository)"`
+//! Example: `"MyApp/1.0 (contact@example.com; +https://github.com/your/repo)"`
 
 use std::sync::Arc;
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -251,7 +251,7 @@ impl ClientBuilder {
     /// To enable OAuth2 authentication, you must set `client_id`, `client_secret`, and `callback_url` before calling `.build()`.
     ///
     /// # Arguments
-    /// - `client_id` ([`String`]): The OAuth2 client ID obtained from the EVE Online developer portal.
+    /// - `client_id` (`&str`): The OAuth2 client ID obtained from the EVE Online developer portal.
     ///
     /// # Returns
     /// - [`ClientBuilder`]: instance with updated client ID configuration.
@@ -270,7 +270,7 @@ impl ClientBuilder {
     /// To enable OAuth2 authentication, you must set `client_id`, `client_secret`, and `callback_url` before calling `.build()`.
     ///
     /// # Arguments
-    /// - `client_secret` ([`String`]): The OAuth2 client secret obtained from the EVE Online developer portal.
+    /// - `client_secret` (`&str`): The OAuth2 client secret obtained from the EVE Online developer portal.
     ///
     /// # Returns
     /// - [`ClientBuilder`]: instance with updated client secret configuration.
@@ -289,7 +289,7 @@ impl ClientBuilder {
     /// To enable OAuth2 authentication, you must set `client_id`, `client_secret`, and `callback_url` before calling `.build()`.
     ///
     /// # Arguments
-    /// - `callback_url` ([`String`]): The callback URL which matches the one set in your EVE Online developer portal application.
+    /// - `callback_url` (`&str`): The callback URL which matches the one set in your EVE Online developer portal application.
     ///
     /// # Returns
     /// - [`ClientBuilder`] instance with updated callback URL configuration.

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,22 +4,23 @@
 //! SSO (single sign-on) using OAuth2, & caching & refreshing JWT keys to validate tokens.
 //!
 //! ## Usage
-//!
-//! Creating a basic default ESI client with a user agent
-//!
+//! ### Creating a basic ESI client
 //! ```rust
-//! // Set a user_agent to identify your application when making requests
+//! // Always set a user_agent to identify your application when making requests
 //! let user_agent = "MyApp/1.0 (contact@example.com; +https://github.com/your/repository)";
 //!
-//! // Create a basic ESI client with user_agent
-//! let esi_client = eve_esi::Client::new(user_agent).expect("Failed to build Client");
+//! // Create a basic ESI client with the user_agent
+//! let esi_client = eve_esi::Client::new(user_agent).expect("Failed to build ESI Client");
 //! ```
+//!
+//! For a more complete example of a basic ESI client, see the [Axum example](https://github.com/hyziri/eve_esi/blob/main/examples/axum.rs)
 //!
 //! To build an ESI client for OAuth2 & authenticated ESI routes, please see the [`crate::builder`] module docs.
 //!
 //! ## Warning
-//! EVE ESI API requires setting a proper user agent. Failure to do so may result in rate limiting or API errors.
-//! Include application name, version, and contact information in your user agent string.
+//! EVE Online requires setting a proper user agent. Failure to do so may result in rate limiting or API errors.
+//! Include application name, version, and contact information in your user agent string as well as the repository
+//! of your application if it is open source.
 //!
 //! Example: `"MyApp/1.0 (contact@example.com; +https://github.com/your/repo)"`
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,10 +45,13 @@
 //!     .build()
 //!     .expect("Failed to build ESI Config");
 //!
+//! // Always set a user_agent to identify your application when making requests
+//! let user_agent = "MyApp/1.0 (contact@example.com; +https://github.com/your/repository)";
+//!
 //! // Apply config settings to Client
 //! let esi_client = eve_esi::Client::builder()
 //!     .config(config)
-//!     .user_agent("MyApp/1.0 (contact@example.com; +https://github.com/your/repository")
+//!     .user_agent(user_agent)
 //!     .build()
 //!     .expect("Failed to build ESI Client");
 //! ```

--- a/src/endpoints/mod.rs
+++ b/src/endpoints/mod.rs
@@ -25,7 +25,7 @@
 //! ## Usage
 //! ### Public ESI Endpoints
 //! **Prerequisites:**
-//! - **ESI Client:** Setup a basic ESI client as demonstrated in [`crate::builder`] module docs
+//! - **ESI Client:** Setup a basic ESI client as demonstrated in [`crate::client`] module docs
 //!
 //! ```no_run
 //! use eve_esi::Client;
@@ -44,9 +44,9 @@
 //! ### Authenticated ESI Endpoints
 //! **Prerequisites:**
 //! - **ESI Client:** Setup an ESI client for OAuth2 as demonstrated in [`crate::builder`] module docs
-//! - **User Login:** You will need the character to login first in order to get an access token
+//! - **User Login:** You will need the character to login first in order to retrieve an access token
 //!   using an authorization code. You will need a login route as demonstrated in the [`crate::oauth2::login`]
-//!   module docs.
+//!   module docs. Make sure you request the scopes required for the endpoint!
 //! - **Access Token:** You will get this by getting a character's token in the callback route
 //!   using the authorization code provided after login as demonstrated in the [`crate::oauth2::token`]
 //!   module docs
@@ -54,16 +54,16 @@
 //! ```no_run
 //! use eve_esi::Client;
 //!
-//! // Fetch character research agents from an authenticated ESI endpoint
-//! async fn get_character_research_agents(
+//! // Fetch character notifications from an authenticated ESI endpoint
+//! async fn get_character_notifications(
 //!     esi_client: Client,
 //!     character_id: i64,
 //!     access_token: &str
 //! ) {
-//!     // Get character research agents for character_id using the access_token
-//!     let research_agents = esi_client
+//!     // Get character notifications for character_id using the access_token
+//!     let notifications = esi_client
 //!         .character()
-//!         .get_agents_research(&access_token, character_id)
+//!         .get_character_notifications(&access_token, character_id)
 //!         .await
 //!         .unwrap();
 //! }

--- a/src/error.rs
+++ b/src/error.rs
@@ -96,7 +96,7 @@ pub enum Error {
 /// - [`MissingCallbackUrl`](ConfigError::MissingCallbackUrl): The [crate::Client] is missing a `callback_url`
 /// - [`InvalidCallbackUrl`](ConfigError::InvalidCallbackUrl): The `callback_url` is in an invalid URL format.
 /// - [`InvalidAuthUrl`](ConfigError::InvalidAuthUrl): EVE OAuth2 authorization URL is in an invalid URL format.
-/// - [`InvalidTokenUrl](ConfigError::InvalidTokenUrl): EVE OAuth2 token URL is in an invalid URL format.
+/// - [`InvalidTokenUrl`](ConfigError::InvalidTokenUrl): EVE OAuth2 token URL is in an invalid URL format.
 /// - [`InvalidBackgroundRefreshThreshold`](ConfigError::InvalidBackgroundRefreshThreshold): JWT key cache
 ///   background refresh threshold percentage is not between 0 and 100
 ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,4 @@
-//! Error types for the EVE ESI client library.
+//! # EVE ESI Runtime & Config Errors
 //!
 //! This module defines the top-level error types used throughout the crate, providing
 //! structured and descriptive error handling for both OAuth2 authentication and HTTP requests.
@@ -15,7 +15,7 @@
 //!
 //! See the documentation for [`enum@Error`] and [`ConfigError`] for more details on each error variant.
 //!
-//! # Example
+//! ## Usage Example
 //!
 //! ```rust
 //! // Don't set any OAuth2 related settings
@@ -53,17 +53,6 @@ pub use crate::oauth2::error::OAuthError;
 /// all possible error conditions, including OAuth2 authentication errors and HTTP request failures.
 ///
 /// See the [module-level documentation](self) for an overview and usage example.
-///
-/// # Variants
-/// - [`ConfigError`](Error::ConfigError) - Errors due to configuration issues when building an [`Client`](crate::Client)
-///   or [`Config`](crate::config::Config)
-/// - [`OAuthError`](Error::OAuthError) - Errors related to OAuth2 authentication. See [`OAuthError`] for details.
-/// - [`ReqwestError`](Error::ReqwestError) - Errors that occur during HTTP requests. See [`reqwest::Error`] for details.
-///
-/// # Usage
-/// You can match on [`enum@Error`] to handle errors at a high level, or downcast to more specific
-/// error types for granular handling.
-///
 #[derive(Error, Debug)]
 pub enum Error {
     /// Config errors related to building a [`Config`](crate::Config) or [`Client`](crate::Client)
@@ -89,20 +78,6 @@ pub enum Error {
 /// improper URL format or an invalid JWT key background refresh threshold.
 ///
 /// See the [module-level documentation](self) for an overview and usage example.
-///
-/// # Variants
-/// - [`MissingClientId`](ConfigError::MissingClientId): The [crate::Client] is missing a `client_id`
-/// - [`MissingClientSecret`](ConfigError::MissingClientSecret): The [crate::Client] is missing a `client_secret`
-/// - [`MissingCallbackUrl`](ConfigError::MissingCallbackUrl): The [crate::Client] is missing a `callback_url`
-/// - [`InvalidCallbackUrl`](ConfigError::InvalidCallbackUrl): The `callback_url` is in an invalid URL format.
-/// - [`InvalidAuthUrl`](ConfigError::InvalidAuthUrl): EVE OAuth2 authorization URL is in an invalid URL format.
-/// - [`InvalidTokenUrl`](ConfigError::InvalidTokenUrl): EVE OAuth2 token URL is in an invalid URL format.
-/// - [`InvalidBackgroundRefreshThreshold`](ConfigError::InvalidBackgroundRefreshThreshold): JWT key cache
-///   background refresh threshold percentage is not between 0 and 100
-///
-/// # Usage
-/// You can match on [`ConfigError`] to handle errors at a high level, or downcast to more specific
-/// error types for granular handling.
 #[derive(Error, Debug)]
 pub enum ConfigError {
     /// The [crate::Client] is missing a `client_id`

--- a/src/esi/mod.rs
+++ b/src/esi/mod.rs
@@ -41,7 +41,7 @@
 //!
 //!     // Make the request with the earlier defined struct
 //!     // - The first type, `<Vec<CharacterAffiliations>`, represents the response body to deserialize
-//!     // - The second type, `Vec<i64>`, represents the request body to serialize
+//!     // - The second type, `Vec<i64>`, represents the request body to serialize (not applicable to GET requests)
 //!     let character_ids = vec![2114794365];
 //!
 //!     let character_affiliations = esi_client

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //!
 //! ### Single Sign-On (OAuth2)
 //!
-//! - [Building scopes to request with a login URL](crate::oauth2::scope)
+//! - [Building scopes to request during login](crate::oauth2::scope)
 //! - [Creating a login URL for single sign-on (OAuth2)](crate::oauth2::login)
 //! - [Fetching an access token](crate::oauth2::token)
 //! - [Validating an access token](crate::oauth2::token)
@@ -33,9 +33,9 @@
 //!
 //! ### Error Types
 //!
-//! - [Runtime errors](crate::error)
-//! - [Configuration errors](crate::error)
-//! - [OAuth2 runtime errors](crate::error)
+//! - [Runtime errors](crate::error::Error)
+//! - [Configuration errors](crate::error::ConfigError)
+//! - [OAuth2 runtime errors](crate::oauth2::error::OAuthError)
 //!
 //! ### Custom Endpoints
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,21 +1,46 @@
 #![warn(missing_docs)]
 
-//! EVE ESI
+//! ## EVE ESI
 //!
 //! A thread-safe, asynchronous client which provides methods & types for interaction with
 //! [EVE Online's ESI](https://developers.eveonline.com/api-explorer) &
 //! [EVE Online's single sign-on (SSO)](https://developers.eveonline.com/docs/services/sso/).
 //!
-//! This crate implements concurrency & caching to provide performance in applications at scale.
-//! For example JSON web token keys (JWT keys) are used to validate tokens after a successful EVE
-//! Online single sign-on login, this crate automatically caches the keys and refreshes them proactively
-//! before expiry in a background task for mimimal latency.
+//! ## ESI Documentation
+//! - <https://developers.eveonline.com/api-explorer>
+//! - <https://developers.eveonline.com/docs/services/sso/>
 //!
-//! # References
-//! - [ESI API Documentation](https://developers.eveonline.com/api-explorer)
-//! - [EVE SSO Documentation](https://developers.eveonline.com/docs/services/sso/)
+//! ## Quickstart
 //!
-//! # Usage
+//! ### ESI Client
+//!
+//! - [Creating a basic ESI client for public ESI endpoints](crate::client)
+//! - [Building an ESI client for OAuth2 & authenticated ESI endpoints](crate::builder)
+//! - [Overriding an ESI client's defaults](crate::config)
+//!
+//! ### Making ESI Requests
+//!
+//! - [Making requests to public ESI endpoints](crate::endpoints)
+//! - [Making requests to authenticated ESI endpoints](crate::endpoints)
+//!
+//! ### Single Sign-On (OAuth2)
+//!
+//! - [Creating a login URL for single sign-on (OAuth2)](crate::oauth2::login)
+//! - [Fetching an access token](crate::oauth2::token)
+//! - [Validating an access token](crate::oauth2::token)
+//! - [Refreshing an access token](crate::oauth2::token)
+//!
+//! ### Error Types
+//!
+//! - [Runtime errors](crate::error)
+//! - [Configuration errors](crate::error)
+//! - [OAuth2 runtime errors](crate::error)
+//!
+//! ### Custom Endpoints
+//!
+//! - [Adding custom ESI endpoints](crate::esi)
+//!
+//! ## Usage
 //!
 //! Create a new ESI Client instance and request public information about a corporation from ESI.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@
 //!
 //! ### Single Sign-On (OAuth2)
 //!
+//! - [Building scopes to request with a login URL](crate::oauth2::scope)
 //! - [Creating a login URL for single sign-on (OAuth2)](crate::oauth2::login)
 //! - [Fetching an access token](crate::oauth2::token)
 //! - [Validating an access token](crate::oauth2::token)

--- a/src/model/oauth2/jwt_claims.rs
+++ b/src/model/oauth2/jwt_claims.rs
@@ -258,7 +258,7 @@ where
     }
 }
 
-/// Deserializes i64 unix timestamp common for JWTs into DateTime<Utc>
+/// Deserializes i64 unix timestamp common for JWTs into `DateTime<Utc>`
 mod jwt_timestamp_format {
     use chrono::{DateTime, TimeZone, Utc};
     use serde::{self, Deserialize, Deserializer, Serializer};

--- a/src/oauth2/client.rs
+++ b/src/oauth2/client.rs
@@ -6,10 +6,11 @@
 //! This module uses the [`oauth2`](https://crates.io/crates/oauth2) crate to configure
 //! the OAuth2 client for the Client.
 //!
-//! This client is only used internally by the [`Client`](crate::Client).
+//! This client is only used internally by the [`Client`](crate::Client) for OAuth2
 //!
-//! - See [module-level documentation](super) for a higher level overview and usage example
-//! - See [ClientBuilder docs](crate::builder) for instructions on setting up OAuth2 for the eve_esi crate.
+//! See [ClientBuilder docs](crate::builder) for instructions on setting up OAuth2 for the eve_esi crate.
+//!
+//! For an overview & usage examples of OAuth2 with the `eve_esi` crate, see the [module-level documentation](super)
 
 use oauth2::basic::{BasicClient, BasicErrorResponseType, BasicTokenType};
 use oauth2::{

--- a/src/oauth2/error.rs
+++ b/src/oauth2/error.rs
@@ -10,21 +10,6 @@
 //!
 //! For an overview & usage examples of OAuth2 with the `eve_esi` crate, see the [module-level documentation](super)
 //!
-//! ## Variants
-//! ### Configuration Error
-//! - [`OAuthError::OAuth2NotConfigured`]: Error returned when OAuth2 has not been configured for [`Client`](crate::Client).
-//!
-//! ### JWT Key Refresh Errors
-//! - [`OAuthError::JwtKeyRefreshTimeout`]: Error when waiting for another thread to refresh JWT key cache times out
-//! - [`OAuthError::JwtKeyRefreshFailure`]: Error when waiting for another thread to refresh JWT key cache fails
-//! - [`OAuthError::JwtKeyRefreshCooldown`]: Error when JWT key refresh is still in cooldown
-//!
-//! ### JWT Token Errors
-//! - [`OAuthError::RequestTokenError`]: Error when an OAuth2 token fetch request fails
-//! - [`OAuthError::ValidateTokenError`]: Error when JWT key refresh is still in cooldown
-//! - [`OAuthError::NoValidKeyFound`]: Error returned when JWT key cache does not have the ES256 token key needed for validation
-//! - [`OAuthError::CharacterIdParseError]: Error when failing to parse character ID from JWT token claims
-//!
 //! ## Usage Example
 //! ```
 //! let esi_client = eve_esi::Client::builder()

--- a/src/oauth2/error.rs
+++ b/src/oauth2/error.rs
@@ -1,4 +1,4 @@
-//! Errors related to the OAuth2 portion of the EVE ESI crate
+//! # EVE ESI OAuth2 Errors
 //!
 //! Provides an enum for runtime related OAuth2 errors, [`OAuthError`], which provides
 //! detailed error messages as well as instructions on how to
@@ -8,22 +8,24 @@
 //! Possible errors could be not having the [`Client`](crate::Client) configured for OAuth2, an issue validating
 //! a JWT token, or an issue fetching the JWT keys used to validate the token.
 //!
-//! # Variants
-//! ## Configuration Error
+//! For an overview & usage examples of OAuth2 with the `eve_esi` crate, see the [module-level documentation](super)
+//!
+//! ## Variants
+//! ### Configuration Error
 //! - [`OAuthError::OAuth2NotConfigured`]: Error returned when OAuth2 has not been configured for [`Client`](crate::Client).
 //!
-//! ## JWT Key Refresh Errors
+//! ### JWT Key Refresh Errors
 //! - [`OAuthError::JwtKeyRefreshTimeout`]: Error when waiting for another thread to refresh JWT key cache times out
 //! - [`OAuthError::JwtKeyRefreshFailure`]: Error when waiting for another thread to refresh JWT key cache fails
 //! - [`OAuthError::JwtKeyRefreshCooldown`]: Error when JWT key refresh is still in cooldown
 //!
-//! ## JWT Token Errors
+//! ### JWT Token Errors
 //! - [`OAuthError::RequestTokenError`]: Error when an OAuth2 token fetch request fails
 //! - [`OAuthError::ValidateTokenError`]: Error when JWT key refresh is still in cooldown
 //! - [`OAuthError::NoValidKeyFound`]: Error returned when JWT key cache does not have the ES256 token key needed for validation
 //! - [`OAuthError::CharacterIdParseError]: Error when failing to parse character ID from JWT token claims
 //!
-//! # Usage
+//! ## Usage Example
 //! ```
 //! let esi_client = eve_esi::Client::builder()
 //!     .user_agent("MyApp/1.0 (contact@example.com)")

--- a/src/oauth2/jwk/mod.rs
+++ b/src/oauth2/jwk/mod.rs
@@ -44,7 +44,7 @@
 //!     let jwt_keys = esi_client.oauth2().jwk().fetch_and_update_cache().await.unwrap();
 //!
 //!     // Get keys from cache or refresh if cache is empty or expired
-//!     // Will proactively refresh keys if nearing expiration as well
+//!     // Will proactively refresh keys if nearing expiration as well (80% of 3600 seconds have elapsed)
 //!     let jwt_keys = esi_client.oauth2().jwk().get_jwt_keys().await.unwrap();
 //! }
 //!

--- a/src/oauth2/login.rs
+++ b/src/oauth2/login.rs
@@ -19,7 +19,7 @@
 //! // A login API route implemented in the Axum web framework
 //! async fn login(Extension(esi_client): Extension<eve_esi::Client>) -> Response {
 //!    // Build the scopes we wish to request from the user
-//!    let scopes = eve_esi::oauth2::ScopeBuilder::new().public_data().build();
+//!    let scopes = eve_esi::ScopeBuilder::new().public_data().build();
 //!
 //!    // Generate the login url or return an error if one occurs
 //!    let login_url = match esi_client.oauth2().login_url(scopes) {

--- a/src/oauth2/login.rs
+++ b/src/oauth2/login.rs
@@ -3,7 +3,9 @@
 //! Provides the method to create a login URL to begin the EVE Online single sign-on (SSO) process.
 //! See the [OAuth2Api::login_url] method for details.
 //!
-//! See the [module-level documentation](super) for an overview of EVE Online OAuth2 and usage example.
+//! For an overview & usage examples of OAuth2 with the `eve_esi` crate, see the [module-level documentation](super)
+//!
+//!
 
 use oauth2::{CsrfToken, Scope};
 

--- a/src/oauth2/mod.rs
+++ b/src/oauth2/mod.rs
@@ -16,31 +16,6 @@
 //! - [`scope`]: Builder to create scopes to request during the login process
 //! - [`jwk`]: Methods to handle JSON web keys used to validate authentication tokens
 //! - [`error`]: Error enum for any OAuth2 related errors.
-//!
-//! # Example
-//! ```
-//! let esi_client = eve_esi::Client::builder()
-//!     .user_agent("MyApp/1.0 (contact@example.com)")
-//!     .client_id("client_id")
-//!     .client_secret("client_secret")
-//!     .callback_url("http://localhost:8080/callback")
-//!     .build()
-//!     .expect("Failed to build Client");
-//!
-//! // Build scopes requesting only publicData
-//! let scopes = eve_esi::oauth2::ScopeBuilder::new()
-//!     .public_data()
-//!     .build();
-//!
-//! // Create a login URL
-//! let auth_data = esi_client
-//!     .oauth2()
-//!     .login_url(scopes)
-//!     .expect("Failed to create a login url");
-//!
-//! // Print the created login URL
-//! println!("Login URL: {}", auth_data.login_url);
-//! ```
 
 pub mod error;
 pub mod jwk;

--- a/src/oauth2/mod.rs
+++ b/src/oauth2/mod.rs
@@ -6,10 +6,10 @@
 //! Default settings for OAuth2 such as JWT key cache handling used to validate tokens or
 //! the endpoints used for EVE OAuth2 can be overridden using the [`Config`](crate::Config).
 //!
-//! # References
-//! - [EVE SSO Documentation](https://developers.eveonline.com/docs/services/sso/)
+//! ## References
+//! - <https://developers.eveonline.com/docs/services/sso/>
 //!
-//! # Modules
+//! ## Modules
 //!
 //! - [`login`]: Methods to begin the OAuth2 login process
 //! - [`token`]: Methods to retrieve, validate, & refresh OAuth2 tokens

--- a/src/oauth2/oauth2.rs
+++ b/src/oauth2/oauth2.rs
@@ -3,7 +3,7 @@
 //! The [`OAuth2Api`] struct provides access to oauth2 related methods for
 //! the [`Client`] using the [`Client::oauth2`] method.
 //!
-//! For more details regarding using OAuth2 with the eve_esi crate, see [module-level documentation](super)
+//! For an overview & usage examples of OAuth2 with the `eve_esi` crate, see the [module-level documentation](super)
 
 use crate::Client;
 

--- a/src/oauth2/scope/character.rs
+++ b/src/oauth2/scope/character.rs
@@ -52,54 +52,72 @@ impl CharacterScopes {
     }
 
     /// Adds the `esi-characters.read_agents_research.v1` scope
+    ///
+    /// Access to retrieve information on character's research agents
     pub fn read_agents_research(mut self) -> Self {
         self.scopes.push(READ_AGENTS_RESEARCH.to_string());
         self
     }
 
     /// Adds the `esi-characters.read_blueprints.v1` scope
+    ///
+    /// Access to retrieve information on character's blueprints
     pub fn read_blueprints(mut self) -> Self {
         self.scopes.push(READ_BLUEPRINTS.to_string());
         self
     }
 
     /// Adds the `esi-characters.read_contacts.v1` scope
+    ///
+    /// Access to read a character's contacts
     pub fn read_contacts(mut self) -> Self {
         self.scopes.push(READ_CONTACTS.to_string());
         self
     }
 
     /// Adds the `esi-characters.read_fatigue.v1` scope
+    ///
+    /// Access to retrieve information on character's jump fatigue status
     pub fn read_fatigue(mut self) -> Self {
         self.scopes.push(READ_FATIGUE.to_string());
         self
     }
 
     /// Adds the `esi-characters.read_medals.v1` scope
+    ///
+    /// Access to retrieve information on character's medals
     pub fn read_medals(mut self) -> Self {
         self.scopes.push(READ_MEDALS.to_string());
         self
     }
 
     /// Adds the `esi-characters.read_notifications.v1` scope
+    ///
+    /// Access to retrieve the character's notifications
     pub fn read_notifications(mut self) -> Self {
         self.scopes.push(READ_NOTIFICATIONS.to_string());
         self
     }
 
     /// Adds the `esi-characters.read_corporation_roles.v1` scope
+    ///
+    /// Access to read the character's corporation roles
     pub fn read_corporation_roles(mut self) -> Self {
         self.scopes.push(READ_CORPORATION_ROLES.to_string());
         self
     }
 
     /// Adds the `esi-characters.read_standings.v1` scope
+    ///
+    /// Access to read the character's standings
     pub fn read_standings(mut self) -> Self {
         self.scopes.push(READ_STANDINGS.to_string());
         self
     }
 
     /// Adds the `esi-characters.read_titles.v1` scope
+    ///
+    /// Access to read the character's corporation titles
     pub fn read_titles(mut self) -> Self {
         self.scopes.push(READ_TITLES.to_string());
         self

--- a/src/oauth2/scope/corporation.rs
+++ b/src/oauth2/scope/corporation.rs
@@ -58,66 +58,88 @@ impl CorporationScopes {
     }
 
     /// Adds the `esi-corporations.read_blueprints.v1` scope
+    ///
+    /// Access to retrieve information on corporation's blueprints
     pub fn read_blueprints(mut self) -> Self {
         self.scopes.push(READ_BLUEPRINTS.to_string());
         self
     }
 
     /// Adds the `esi-corporations.read_container_logs.v1` scope
+    ///
+    /// Access to read information on corporation container logs
     pub fn read_container_logs(mut self) -> Self {
         self.scopes.push(READ_CONTAINER_LOGS.to_string());
         self
     }
 
     /// Adds the `esi-corporations.read_divisions.v1` scope
+    ///
+    /// Access to retrieve information on corporation's wallet & hangar divisions
     pub fn read_divisions(mut self) -> Self {
         self.scopes.push(READ_DIVISIONS.to_string());
         self
     }
 
     /// Adds the `esi-corporations.read_facilities.v1` scope
+    ///
+    /// Access to retrieve information on corporation's industry facilities
     pub fn read_facilities(mut self) -> Self {
         self.scopes.push(READ_FACILITIES.to_string());
         self
     }
 
     /// Adds the `esi-corporations.read_medals.v1` scope
+    ///
+    /// Access to retrieve information on corporation's medals
     pub fn read_medals(mut self) -> Self {
         self.scopes.push(READ_MEDALS.to_string());
         self
     }
 
     /// Adds the `esi-corporations.track_members.v1` scope
+    ///
+    /// Access to member tracking-related information for a corporation
     pub fn track_members(mut self) -> Self {
         self.scopes.push(TRACK_MEMBERS.to_string());
         self
     }
 
     /// Adds the `esi-corporations.read_titles.v1` scope
+    ///
+    /// Access to retrieve information on a corporation's member titles
     pub fn read_titles(mut self) -> Self {
         self.scopes.push(READ_TITLES.to_string());
         self
     }
 
     /// Adds the `esi-corporations.read_corporation_membership.v1` scope
+    ///
+    /// Access to read roles & membership for a corporation
     pub fn read_corporation_membership(mut self) -> Self {
         self.scopes.push(READ_CORPORATION_MEMBERSHIP.to_string());
         self
     }
 
     /// Adds the `esi-corporations.read_standings.v1` scope
+    ///
+    /// Access to retrieve information on a corporation's NPC standings
     pub fn read_standings(mut self) -> Self {
         self.scopes.push(READ_STANDINGS.to_string());
         self
     }
 
     /// Adds the `esi-corporations.read_starbases.v1` scope
+    ///
+    /// Access to retrieve information on a corporation's starbases (POSes)
     pub fn read_starbases(mut self) -> Self {
         self.scopes.push(READ_STARBASES.to_string());
         self
     }
 
     /// Adds the `esi-corporations.read_structures.v1` scope
+    ///
+    /// Access to retrieve information on corporation's structures
     pub fn read_structures(mut self) -> Self {
         self.scopes.push(READ_STRUCTURES.to_string());
         self

--- a/src/oauth2/scope/mod.rs
+++ b/src/oauth2/scope/mod.rs
@@ -3,12 +3,16 @@
 //! This module provides the [`ScopeBuilder`] & related modules with methods to build a list of scopes to request during
 //! login in a type-safe manner.
 //!
-//! # Modules
+//! For an overview & usage examples of OAuth2 with the `eve_esi` crate, see the [module-level documentation](super)
+//!
+//! ## Modules
 //!
 //! - [`builder`]: Provides the [`ScopeBuilder`] to build a list of scopes
 //! - [`character`]: Provides the [`CharacterScopes`] struct to be used with the [`ScopeBuilder::character`] method
+//! - [`corporation`]: Provides the [`CorporationScopes`] struct to be used with the [`ScopeBuilder::corporation`] method
+//! - [`wallet`]: Provides the [`WalletScopes`] struct to be used with the [`ScopeBuilder::wallet`] method
 //!
-//! # Usage
+//! ## Usage Example
 //!
 //! ```rust
 //! use eve_esi::ScopeBuilder;

--- a/src/oauth2/scope/wallet.rs
+++ b/src/oauth2/scope/wallet.rs
@@ -7,7 +7,7 @@
 //! # Methods
 //! - [`WalletScopes::new`]: Creates a new instance of [`WalletScopes`]
 
-/// Access to retrieve information regarding corporation wallets
+/// Access to retrieve information for character's corporation wallets
 pub const READ_CORPORATION_WALLETS: &str = "esi-wallet.read_corporation_wallets.v1";
 
 /// Struct with methods for listing wallet scopes to request for OAuth2
@@ -27,6 +27,8 @@ impl WalletScopes {
     }
 
     /// Adds the `esi-wallet.read_corporation_wallets.v1` scope
+    ///
+    /// Access to retrieve information for character's corporation wallets
     pub fn read_corporation_wallets(mut self) -> Self {
         self.scopes.push(READ_CORPORATION_WALLETS.to_string());
         self

--- a/src/oauth2/token.rs
+++ b/src/oauth2/token.rs
@@ -20,17 +20,19 @@
 //! use oauth2::TokenResponse;
 //! use serde::Deserialize;
 //!
+//! // URL parameters for the callback route
 //! #[derive(Deserialize)]
 //! struct CallbackParams {
 //!    state: String,
 //!    code: String,
 //! }
 //!
+//! // A callback route implemented in the Axum web framework
 //! async fn callback_route(
 //!     Extension(esi_client): Extension<eve_esi::Client>,
 //!     params: Query<CallbackParams>,
 //! ) -> Result<(), eve_esi::Error> {
-//!     ///Validate state to prevent CSRF...
+//!     // Validate state here to prevent CSRF...
 //!
 //!     // Fetch the token
 //!     let token = esi_client
@@ -39,16 +41,16 @@
 //!         .await?;
 //!
 //!     let access_token = token.access_token();
-//!     // Refresh token should always be Some for EVE Online's OAuth2
+//!     // Refresh token will be None if no scopes were requested during login
 //!     let refresh_token = token.refresh_token().expect("Expected refresh token, found None");
 //!
-//!     // Validate the token
+//!     // Validate the access token to access the claims
 //!     let claims = esi_client
 //!         .oauth2()
 //!         .validate_token(access_token.secret().to_string())
 //!         .await?;
 //!
-//!     // Extract character ID
+//!     // Use helper function to get character ID from the claims
 //!     let character_id = claims.character_id()?;
 //!
 //!     // Refresh the token
@@ -202,7 +204,7 @@ impl<'a> OAuth2Api<'a> {
     /// See <https://developers.eveonline.com/docs/services/sso/#validating-jwt-tokens>
     ///
     /// # Arguments
-    /// - `token_secret` ([`String`]): The access token secret as a string. You can use
+    /// - `token_secret` ([`String`]): The access token secret as a stribuilderng. You can use
     ///   `token.access_token().secret().to_string()` on the token returned from [`Self::get_token`].
     ///
     /// # Errors

--- a/src/oauth2/token.rs
+++ b/src/oauth2/token.rs
@@ -12,7 +12,7 @@
 //! ## ESI Documentation
 //! - <https://developers.eveonline.com/docs/services/sso/>
 //!
-//! ## Usage
+//! ## Usage Example
 //!
 //! This demonstrates an example of a callback API route implemented in the Axum web framework.
 //! See [SSO example](https://github.com/hyziri/eve_esi/blob/main/examples/sso.rs) for a more complete demonstration.
@@ -29,7 +29,7 @@
 //!    code: String,
 //! }
 //!
-//! // A callback route implemented in the Axum web framework
+//! // A callback API route implemented in the Axum web framework
 //! async fn callback_route(
 //!     Extension(esi_client): Extension<eve_esi::Client>,
 //!     params: Query<CallbackParams>,

--- a/src/oauth2/token.rs
+++ b/src/oauth2/token.rs
@@ -2,6 +2,8 @@
 //!
 //! Methods for fetching, refreshing, & validating tokens retrieved from EVE Online's OAuth2 API.
 //!
+//! For an overview & usage examples of OAuth2 with the `eve_esi` crate, see the [module-level documentation](super)
+//!
 //! ## Methods
 //! - [`OAuth2Api::get_token`]: Retrieves a token from EVE Online's OAuth2 API
 //! - [`OAuth2Api::get_token_refresh`]: Retrieves a new token using a refresh token


### PR DESCRIPTION
Update README.md and crate documentation for better examples and cleanliness.

- The README.md usage examples are instead now within the crate documentation, keeping the README.md more concise and feature-oriented rather than technical.
- The README.md has had 2 new badges added. The wakatime badge which indicates total time spent working on this crate as well as the Discord badge which links to [The Order of Autumn Discord](https://discord.gg/HjaGsBBtFg) where users of this crate can ask for assistance with any issues they may encounter.
- `lib.rs` documentation now provides a "Quickstart" section which provides links for core functionality of the crate such as creating an ESI client, making ESI endpoint requests, using OAuth2 with the ESI client, and making custom ESI endpoints with underlying ESI request utility functions.
- Module examples have been updated across `client.rs`, `builder.rs`, `config.rs`, `oauth2/login.rs`, `oauth2/token.rs`, & `oauth2/scope/mod.rs` to provide a usage demonstration as well as highlight the prerequisites needed for each example.
- Error enum documentation has been updated to remove the variants field 
- Scope documentation has been updated to include in the scope methods a description of what the scope actually does