### PR TITLE
0.4.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -411,7 +411,7 @@ dependencies = [
 
 [[package]]
 name = "eve_esi"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "eve_esi"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Hyziri <hyziri@protonmail.com>"]
 edition = "2021"
 description = "Thread-safe, asynchronous client for EVE Online's ESI & OAuth2"
 keywords = ["eve_online", "esi", "eve",  "eve_esi", "eve_oauth2"]
 repository = "https://github.com/hyziri/eve_esi"
+documentation = "https://docs.rs/eve_esi/latest/eve_esi/"
 license = "MIT"
 readme = "README.md"
 include = ["/src", "LICENSE", "README.md"]

--- a/examples/sso.rs
+++ b/examples/sso.rs
@@ -122,7 +122,7 @@ async fn main() {
 
 async fn login(session: Session, Extension(esi_client): Extension<eve_esi::Client>) -> Response {
     // Build the scopes we wish to request from the user
-    let scopes = eve_esi::oauth2::ScopeBuilder::new().public_data().build();
+    let scopes = eve_esi::ScopeBuilder::new().public_data().build();
 
     // Generate the login url or return an error if one occurs
     let login_url = match esi_client.oauth2().login_url(scopes) {

--- a/src/endpoints/alliance.rs
+++ b/src/endpoints/alliance.rs
@@ -5,10 +5,11 @@
 //!
 //! For an overview & usage examples, see the [endpoints module documentation](super)
 //!
-//! # ESI Documentation
+//! ## ESI Documentation
 //! - <https://developers.eveonline.com/api-explorer>
 //!
-//! # Methods
+//! ## Endpoints (4)
+//! ### Public (4)
 //! - [`AllianceApi::list_all_alliances`]: Retrieves a list of IDs of every alliance in EVE Online
 //! - [`AllianceApi::get_alliance_information`]: Retrieves public information for the requested alliance_id
 //! - [`AllianceApi::list_alliance_corporations`]: Retrieves the IDs of all corporations part of the requested alliance_id

--- a/src/endpoints/character.rs
+++ b/src/endpoints/character.rs
@@ -5,17 +5,29 @@
 //!
 //! For an overview & usage examples, see the [endpoints module documentation](super)
 //!
-//! # ESI Documentation
+//! ## ESI Documentation
 //! - <https://developers.eveonline.com/api-explorer>
 //!
-//! # Methods
+//! ## Endpoints (11)
+//! ### Public (3)
 //! - [`CharacterApi::get_character_public_information`]: Retrieves the public information of a specific character
-//! - [`CharacterApi::character_affiliation`]: Retrieve affiliations for a list of characters
+//! - [`CharacterApi::get_corporation_history`]: Retrieves the public corporation history of the provided character ID
+//! - [`CharacterApi::get_character_portraits`]: Retrieves the image URLs of a chacter's portraits with various dimensions
+//!
+//! ### Authenticated (9)
 //! - [`CharacterApi::get_agents_research`]: Retrieves character's research agents using the character's ID
+//! - [`CharacterApi::get_blueprints`]: Retrieves character's blueprints using the character's ID & page to fetch of the blueprint list
+//! - [`CharacterApi::calculate_a_cspa_charge_cost`]: Calculates CSPA cost for evemailing a list of characters with the provided character ID
+//! - [`CharacterApi::get_jump_fatigue`]: Retrieves jump fatigue for the provided character's ID
+//! - [`CharacterApi::get_medals`]: Retrieves a list of medals for the provided character ID
+//! - [`CharacterApi::get_character_notifications`]: Retrieves a list of character's notifications
+//! - [`CharacterApi::get_character_corporation_roles`]: Retrieves a list of the provided character ID's corporation roles
+//! - [`CharacterApi::get_standings`]: Retrieves a paginated list of NPC standing entries for the provided character ID
+//! - [`CharacterApi::get_character_corporation_titles`]: Retrieves a list of the provided character ID's corporation titles
 
 use crate::error::Error;
-use crate::model::universe::Standing;
-use crate::oauth2::scope::CharacterScopes;
+use crate::model::standing::Standing;
+use crate::scope::CharacterScopes;
 use crate::{Client, ScopeBuilder};
 
 use crate::model::asset::Blueprint;
@@ -98,7 +110,7 @@ impl<'a> CharacterApi<'a> {
         /// - <https://developers.eveonline.com/api-explorer#/schemas/CharactersCharacterIdAgentsResearchGet>
         ///
         /// # Required Scopes
-        /// - [`CharacterScopes::read_agents_research`](crate::oauth2::scope::CharacterScopes::read_agents_research):
+        /// - [`CharacterScopes::read_agents_research`](crate::scope::CharacterScopes::read_agents_research):
         ///   `esi-characters.read_agents_research.v1`
         ///
         /// # Arguments
@@ -129,7 +141,7 @@ impl<'a> CharacterApi<'a> {
         /// - <https://developers.eveonline.com/api-explorer#/operations/GetCharactersCharacterIdBlueprints>
         ///
         /// # Required Scopes
-        /// - [`CharacterScopes::read_blueprints`](crate::oauth2::scope::CharacterScopes::read_blueprints):
+        /// - [`CharacterScopes::read_blueprints`](crate::scope::CharacterScopes::read_blueprints):
         ///   `esi-characters.read_blueprints.v1`
         ///
         /// # Arguments
@@ -213,7 +225,7 @@ impl<'a> CharacterApi<'a> {
         /// - <https://developers.eveonline.com/api-explorer#/operations/GetCharactersCharacterIdFatigue>
         ///
         /// # Required Scopes
-        /// - [`CharacterScopes::read_fatigue`](crate::oauth2::scope::CharacterScopes::read_fatigue):
+        /// - [`CharacterScopes::read_fatigue`](crate::scope::CharacterScopes::read_fatigue):
         ///   `esi-characters.read_fatigue.v1`
         ///
         /// # Arguments
@@ -242,7 +254,7 @@ impl<'a> CharacterApi<'a> {
         /// - <https://developers.eveonline.com/api-explorer#/operations/GetCharactersCharacterIdMedals>
         ///
         /// # Required Scopes
-        /// - [`CharacterScopes::read_medals`](crate::oauth2::scope::CharacterScopes::read_medals):
+        /// - [`CharacterScopes::read_medals`](crate::scope::CharacterScopes::read_medals):
         ///   `esi-characters.read_medals.v1`
         ///
         /// # Arguments
@@ -271,7 +283,7 @@ impl<'a> CharacterApi<'a> {
         /// - <https://developers.eveonline.com/api-explorer#/operations/GetCharactersCharacterIdNotifications>
         ///
         /// # Required Scopes
-        /// - [`CharacterScopes::read_notifications`](crate::oauth2::scope::CharacterScopes::read_notifications):
+        /// - [`CharacterScopes::read_notifications`](crate::scope::CharacterScopes::read_notifications):
         ///   `esi-characters.read_notifications.v1`
         ///
         /// # Arguments
@@ -300,7 +312,7 @@ impl<'a> CharacterApi<'a> {
         /// - <https://developers.eveonline.com/api-explorer#/operations/GetCharactersCharacterIdNotificationsContacts>
         ///
         /// # Required Scopes
-        /// - [`CharacterScopes::read_notifications`](crate::oauth2::scope::CharacterScopes::read_notifications):
+        /// - [`CharacterScopes::read_notifications`](crate::scope::CharacterScopes::read_notifications):
         ///   `esi-characters.read_notifications.v1`
         ///
         /// # Arguments
@@ -352,7 +364,7 @@ impl<'a> CharacterApi<'a> {
         /// - <https://developers.eveonline.com/api-explorer#/operations/GetCharactersCharacterIdRoles>
         ///
         /// # Required Scopes
-        /// - [`CharacterScopes::read_corporation_roles`](crate::oauth2::scope::CharacterScopes::read_corporation_roles):
+        /// - [`CharacterScopes::read_corporation_roles`](crate::scope::CharacterScopes::read_corporation_roles):
         ///   `esi-characters.read_corporation_roles.v1`
         ///
         /// # Arguments
@@ -380,7 +392,7 @@ impl<'a> CharacterApi<'a> {
         /// - <https://developers.eveonline.com/api-explorer#/operations/GetCharactersCharacterIdStandings>
         ///
         /// # Required Scopes
-        /// - [`CharacterScopes::read_standings`](crate::oauth2::scope::CharacterScopes::read_standings):
+        /// - [`CharacterScopes::read_standings`](crate::scope::CharacterScopes::read_standings):
         ///   `esi-characters.read_standings.v1`
         ///
         /// # Arguments
@@ -408,7 +420,7 @@ impl<'a> CharacterApi<'a> {
         /// - <https://developers.eveonline.com/api-explorer#/operations/GetCharactersCharacterIdTitles>
         ///
         /// # Required Scopes
-        /// - [`CharacterScopes::read_titles`](crate::oauth2::scope::CharacterScopes::read_titles):
+        /// - [`CharacterScopes::read_titles`](crate::scope::CharacterScopes::read_titles):
         ///   `esi-characters.read_titles.v1`
         ///
         /// # Arguments

--- a/src/endpoints/corporation.rs
+++ b/src/endpoints/corporation.rs
@@ -5,11 +5,35 @@
 //!
 //! For an overview & usage examples, see the [endpoints module documentation](super)
 //!
-//! # ESI Documentation
+//! ## ESI Documentation
 //! - <https://developers.eveonline.com/api-explorer>
 //!
-//! # Methods
+//! ## Endpoints (22)
+//! ### Public (4)
+//! - [`CorporationApi::get_npc_corporations`]: Fetches a list of all NPC corporation IDs in EVE Online
 //! - [`CorporationApi::get_corporation_information`]: Fetches a corporation’s public information from ESI using the corporation ID
+//! - [`CorporationApi::get_alliance_history`]: Fetches a corporation's alliance history using the provided corporation ID
+//! - [`CorporationApi::get_corporation_icon`]: Fetches a corporation's icon using the provided corporation ID
+//!
+//! ### Authenticated (18)
+//! - [`CorporationApi::get_corporation_blueprints`]: Fetches a list of blueprint entries for the provided corporation ID
+//! - [`CorporationApi::get_all_corporation_alsc_logs`]: Fetches audit log secure container (ALSC) log entries for the provided corporation ID
+//! - [`CorporationApi::get_corporation_divisions`]: Fetches a list of hangar & wallet divisions for the provided corporation ID
+//! - [`CorporationApi::get_corporation_facilities`]: Fetches a list of industry facilities for the provided corporation ID
+//! - [`CorporationApi::get_corporation_medals`]: Fetches a paginated list of medals for the provided corporation ID
+//! - [`CorporationApi::get_corporation_issued_medals`]: Fetches a paginated list of issued medals for the provided corporation ID
+//! - [`CorporationApi::get_corporation_members`]: Fetches a list of character IDs of all members part of the provided corporation ID
+//! - [`CorporationApi::get_corporation_member_limit`]: Fetches the member limit of the provided corporation ID
+//! - [`CorporationApi::get_corporation_members_titles`]: Fetches a list of title IDs for each member of the provided corporation ID
+//! - [`CorporationApi::track_corporation_members`]: Fetches a list of tracking information for each character part of the provided corporation ID
+//! - [`CorporationApi::get_corporation_member_roles`]: Fetches a list of roles for each character part of the provided corporation ID
+//! - [`CorporationApi::get_corporation_member_roles_history`]: Retrieves a paginated list of up to a month of role history for the provided corporation ID
+//! - [`CorporationApi::get_corporation_shareholders`]: Retrieves a paginated list of shareholders for the provided corporation ID
+//! - [`CorporationApi::get_corporation_standings`]: Retrieves a paginated list of NPC standing entries for the provided corporation ID
+//! - [`CorporationApi::get_corporation_starbases`]: Retrieves a paginated list of starbases (POSes) for the provided corporation ID
+//! - [`CorporationApi::get_starbase_detail`]: Retrieves details for a starbase (POS) for the provided starbase ID & corporation ID
+//! - [`CorporationApi::get_corporation_structures`]: Retrieves a paginated list of structure information for the provided corporation ID
+//! - [`CorporationApi::get_corporation_titles`]: Retrieves a list of corporation titles and their respective roles for the provided corporation ID
 
 use crate::error::Error;
 use crate::model::asset::Blueprint;
@@ -20,8 +44,8 @@ use crate::model::corporation::{
     CorporationSecureContainerLog, CorporationShareholder, CorporationStarbase,
     CorporationStarbaseDetails, CorporationStructure, CorporationTitle,
 };
-use crate::model::universe::Standing;
-use crate::oauth2::scope::{CorporationScopes, WalletScopes};
+use crate::model::standing::Standing;
+use crate::scope::{CorporationScopes, WalletScopes};
 use crate::{Client, ScopeBuilder};
 
 /// Provides methods for accessing corporation-related endpoints of the EVE Online ESI API.
@@ -117,7 +141,7 @@ impl<'a> CorporationApi<'a> {
         /// - <https://developers.eveonline.com/api-explorer#/operations/GetCorporationsCorporationIdBlueprints>
         ///
         /// # Required Scopes
-        /// - [`CorporationScopes::read_blueprints`](crate::oauth2::scope::CorporationScopes::read_blueprints):
+        /// - [`CorporationScopes::read_blueprints`](crate::scope::CorporationScopes::read_blueprints):
         ///   `esi-corporations.read_blueprints.v1`
         ///
         /// # Arguments
@@ -153,7 +177,7 @@ impl<'a> CorporationApi<'a> {
         /// - <https://developers.eveonline.com/api-explorer#/operations/GetCorporationsCorporationIdContainersLogs>
         ///
         /// # Required Scopes
-        /// - [`CorporationScopes::read_container_logs`](crate::oauth2::scope::CorporationScopes::read_container_logs):
+        /// - [`CorporationScopes::read_container_logs`](crate::scope::CorporationScopes::read_container_logs):
         ///   `esi-corporations.read_container_logs.v1`
         ///
         /// # Arguments
@@ -187,7 +211,7 @@ impl<'a> CorporationApi<'a> {
         /// - <https://developers.eveonline.com/api-explorer#/operations/GetCorporationsCorporationIdDivisions>
         ///
         /// # Required Scopes
-        /// - [`CorporationScopes::read_divisions`](crate::oauth2::scope::CorporationScopes::read_divisions):
+        /// - [`CorporationScopes::read_divisions`](crate::scope::CorporationScopes::read_divisions):
         ///   `esi-corporations.read_divisions.v1`
         ///
         /// # Arguments
@@ -219,7 +243,7 @@ impl<'a> CorporationApi<'a> {
         /// - <https://developers.eveonline.com/api-explorer#/operations/GetCorporationsCorporationIdFacilities>
         ///
         /// # Required Scopes
-        /// - [`CorporationScopes::read_facilities`](crate::oauth2::scope::CorporationScopes::read_facilities):
+        /// - [`CorporationScopes::read_facilities`](crate::scope::CorporationScopes::read_facilities):
         ///   `esi-corporations.read_facilities.v1`
         ///
         /// # Arguments
@@ -273,7 +297,7 @@ impl<'a> CorporationApi<'a> {
         /// - <https://developers.eveonline.com/api-explorer#/operations/GetCorporationsCorporationIdMedals>
         ///
         /// # Required Scopes
-        /// - [`CorporationScopes::read_medals`](crate::oauth2::scope::CorporationScopes::read_medals):
+        /// - [`CorporationScopes::read_medals`](crate::scope::CorporationScopes::read_medals):
         ///   `esi-corporations.read_medals.v1`
         ///
         /// # Arguments
@@ -310,7 +334,7 @@ impl<'a> CorporationApi<'a> {
         /// - <https://developers.eveonline.com/api-explorer#/operations/GetCorporationsCorporationIdMedalsIssued>
         ///
         /// # Required Scopes
-        /// - [`CorporationScopes::read_medals`](crate::oauth2::scope::CorporationScopes::read_medals):
+        /// - [`CorporationScopes::read_medals`](crate::scope::CorporationScopes::read_medals):
         ///   `esi-corporations.read_medals.v1`
         ///
         /// # Arguments
@@ -341,7 +365,7 @@ impl<'a> CorporationApi<'a> {
         /// - <https://developers.eveonline.com/api-explorer#/operations/GetCorporationsCorporationIdMembers>
         ///
         /// # Required Scopes
-        /// - [`CorporationScopes::read_corporation_membership`](crate::oauth2::scope::CorporationScopes::read_corporation_membership):
+        /// - [`CorporationScopes::read_corporation_membership`](crate::scope::CorporationScopes::read_corporation_membership):
         ///   `esi-corporations.read_corporation_membership.v1`
         ///
         /// # Arguments
@@ -373,7 +397,7 @@ impl<'a> CorporationApi<'a> {
         /// - <https://developers.eveonline.com/api-explorer#/operations/GetCorporationsCorporationIdMembersLimit>
         ///
         /// # Required Scopes
-        /// - [`CorporationScopes::track_members`](crate::oauth2::scope::CorporationScopes::track_members):
+        /// - [`CorporationScopes::track_members`](crate::scope::CorporationScopes::track_members):
         ///   `esi-corporations.track_members.v1`
         ///
         /// # Arguments
@@ -405,7 +429,7 @@ impl<'a> CorporationApi<'a> {
         /// - <https://developers.eveonline.com/api-explorer#/operations/GetCorporationsCorporationIdMembersTitles>
         ///
         /// # Required Scopes
-        /// - [`CorporationScopes::read_titles`](crate::oauth2::scope::CorporationScopes::read_titles):
+        /// - [`CorporationScopes::read_titles`](crate::scope::CorporationScopes::read_titles):
         ///   `esi-corporations.read_titles.v1`
         ///
         /// # Arguments
@@ -437,7 +461,7 @@ impl<'a> CorporationApi<'a> {
         /// - <https://developers.eveonline.com/api-explorer#/operations/GetCorporationsCorporationIdMembertracking>
         ///
         /// # Required Scopes
-        /// - [`CorporationScopes::track_members`](crate::oauth2::scope::CorporationScopes::track_members):
+        /// - [`CorporationScopes::track_members`](crate::scope::CorporationScopes::track_members):
         ///   `esi-corporations.track_members.v1`
         ///
         /// # Arguments
@@ -470,7 +494,7 @@ impl<'a> CorporationApi<'a> {
         /// - <https://developers.eveonline.com/api-explorer#/operations/GetCorporationsCorporationIdRoles>
         ///
         /// # Required Scopes
-        /// - [`CorporationScopes::read_corporation_membership`](crate::oauth2::scope::CorporationScopes::read_corporation_membership):
+        /// - [`CorporationScopes::read_corporation_membership`](crate::scope::CorporationScopes::read_corporation_membership):
         ///   `esi-corporations.read_corporation_membership.v1`
         ///
         /// # Arguments
@@ -503,7 +527,7 @@ impl<'a> CorporationApi<'a> {
         /// - <https://developers.eveonline.com/api-explorer#/operations/GetCorporationsCorporationIdRolesHistory>
         ///
         /// # Required Scopes
-        /// - [`CorporationScopes::read_corporation_membership`](crate::oauth2::scope::CorporationScopes::read_corporation_membership):
+        /// - [`CorporationScopes::read_corporation_membership`](crate::scope::CorporationScopes::read_corporation_membership):
         ///   `esi-corporations.read_corporation_membership.v1`
         ///
         /// # Arguments
@@ -538,7 +562,7 @@ impl<'a> CorporationApi<'a> {
         /// - <https://developers.eveonline.com/api-explorer#/operations/GetCorporationsCorporationIdShareholders>
         ///
         /// # Required Scopes
-        /// - [`WalletScopes::read_corporation_wallets`](crate::oauth2::scope::WalletScopes::read_corporation_wallets):
+        /// - [`WalletScopes::read_corporation_wallets`](crate::scope::WalletScopes::read_corporation_wallets):
         ///   `esi-wallet.read_corporation_wallets.v1`
         ///
         /// # Arguments
@@ -569,7 +593,7 @@ impl<'a> CorporationApi<'a> {
         /// - <https://developers.eveonline.com/api-explorer#/operations/GetCorporationsCorporationIdStandings>
         ///
         /// # Required Scopes
-        /// - [`CorporationScopes::read_standings`](crate::oauth2::scope::CorporationScopes::read_standings):
+        /// - [`CorporationScopes::read_standings`](crate::scope::CorporationScopes::read_standings):
         ///   `esi-corporations.read_standings.v1`
         ///
         /// # Arguments
@@ -603,7 +627,7 @@ impl<'a> CorporationApi<'a> {
         /// - <https://developers.eveonline.com/api-explorer#/operations/GetCorporationsCorporationIdStarbases>
         ///
         /// # Required Scopes
-        /// - [`CorporationScopes::read_starbases`](crate::oauth2::scope::CorporationScopes::read_starbases):
+        /// - [`CorporationScopes::read_starbases`](crate::scope::CorporationScopes::read_starbases):
         ///   `esi-corporations.read_starbases.v1`
         ///
         /// # Arguments
@@ -637,7 +661,7 @@ impl<'a> CorporationApi<'a> {
         /// - <https://developers.eveonline.com/api-explorer#/operations/GetCorporationsCorporationIdStarbasesStarbaseId>
         ///
         /// # Required Scopes
-        /// - [`CorporationScopes::read_starbases`](crate::oauth2::scope::CorporationScopes::read_starbases):
+        /// - [`CorporationScopes::read_starbases`](crate::scope::CorporationScopes::read_starbases):
         ///   `esi-corporations.read_starbases.v1`
         ///
         /// # Arguments
@@ -673,7 +697,7 @@ impl<'a> CorporationApi<'a> {
         /// - <https://developers.eveonline.com/api-explorer#/operations/GetCorporationsCorporationIdStructures>
         ///
         /// # Required Scopes
-        /// - [`CorporationScopes::read_structures`](crate::oauth2::scope::CorporationScopes::read_structures):
+        /// - [`CorporationScopes::read_structures`](crate::scope::CorporationScopes::read_structures):
         ///   `esi-corporations.read_structures.v1`
         ///
         /// # Arguments
@@ -707,7 +731,7 @@ impl<'a> CorporationApi<'a> {
         /// - <https://developers.eveonline.com/api-explorer#/operations/GetCorporationsCorporationIdTitles>
         ///
         /// # Required Scopes
-        /// - [`CorporationScopes::read_titles`](crate::oauth2::scope::CorporationScopes::read_titles):
+        /// - [`CorporationScopes::read_titles`](crate::scope::CorporationScopes::read_titles):
         ///   `esi-corporations.read_titles.v1`
         ///
         /// # Arguments

--- a/src/endpoints/market.rs
+++ b/src/endpoints/market.rs
@@ -1,0 +1,344 @@
+//! # EVE ESI Market Endpoints
+//!
+//! This module provides the [`MarketEndpoints`] struct and associated methods for accessing
+//! market-related ESI endpoints.
+//!
+//! For an overview & usage examples, see the [endpoints module documentation](super)
+//!
+//! ## ESI Documentation
+//! - <https://developers.eveonline.com/api-explorer>
+//!
+//! ## Endpoints (11)
+//! ### Public (6)
+//! - [`MarketEndpoints::get_item_groups`]: Retrieves a list of IDs of market item groups
+//! - [`MarketEndpoints::get_item_group_information`]: Retrieves the information of the provided market item group ID
+//! - [`MarketEndpoints::list_market_prices`]: Retrieves the average & adjusted market prices of all items
+//! - [`MarketEndpoints::list_historical_market_statistics_in_a_region`]: List of entries with historical market statistics for the provided item type ID in provided region ID
+//! - [`MarketEndpoints::list_orders_in_a_region]: Retrieves a list of market orders within the provided region ID and of the specified order type
+//! - [`MarketEndpoints::list_type_ids_relevant_to_a_market`]: Retrieves a list of type IDs that have active market orders for the given region ID
+//!
+//! ### Authenticated (5)
+//! - [`MarketEndpoints::list_open_orders_from_a_character`]: Fetches list of open market orders for the provided character ID
+//! - [`MarketEndpoints::list_historical_orders_by_a_character`]: Fetches list of cancelled & expired market orders for the provided character ID up to 90 days in the past
+//! - [`MarketEndpoints::list_open_orders_from_a_corporation`]: Fetches list of open market orders for the provided corporation ID
+//! - [`MarketEndpoints::list_historical_orders_from_a_corporation`]: Fetches list of cancelled & expired market orders for the provided corporation ID up to 90 days in the past
+//! - [`MarketEndpoints::list_orders_in_a_structure`]: Fetches list of market orders for the provided structure ID
+
+use crate::{
+    model::{
+        enums::market::OrderType,
+        market::{
+            CharacterMarketOrder, CorporationMarketOrder, MarketItemGroupInformation,
+            MarketItemPrices, MarketItemRegionStatistics, MarketRegionOrder, StructureMarketOrder,
+        },
+    },
+    scope::MarketScopes,
+    Client, Error, ScopeBuilder,
+};
+
+/// Provides methods for accessing market-related endpoints of the EVE Online ESI API.
+///
+/// For an overview & usage examples, see the [endpoints module documentation](super)
+pub struct MarketEndpoints<'a> {
+    client: &'a Client,
+}
+
+impl<'a> MarketEndpoints<'a> {
+    /// Creates a new instance of [`MarketEndpoints`].
+    ///
+    /// For an overview & usage examples, see the [endpoints module documentation](super)e
+    ///
+    /// # Arguments
+    /// - `client` (&[`Client`]): ESI client used for making HTTP requests to the ESI endpoints.
+    pub(super) fn new(client: &'a Client) -> Self {
+        Self { client }
+    }
+
+    define_endpoint! {
+        /// Fetches list of open market orders for the provided character ID
+        ///
+        /// For an overview & usage examples, see the [endpoints module documentation](super)
+        ///
+        /// # ESI Documentation
+        /// - <https://developers.eveonline.com/api-explorer#/operations/GetCharactersCharacterIdOrders>
+        ///
+        /// # Required Scopes
+        /// - [`MarketScopes::read_character_orders`](crate::scope::MarketScopes::read_character_orders):
+        ///   `esi-markets.read_character_orders.v1`
+        ///
+        /// # Arguments
+        /// - `access_token`   (`&str`): Access token used for authenticated ESI routes in string format.
+        /// - `character_id`    (`i64`): The ID of the character to retrieve open market orders for
+        ///
+        /// # Returns
+        /// Returns a [`Result`] containing either:
+        /// - `Vec<`[`CharacterMarketOrder`]`>`: List of open market orders for the provided character ID
+        /// - [`Error`]: An error if the fetch request fails
+        auth_get list_open_orders_from_a_character(
+            access_token: &str,
+            character_id: i64
+        ) -> Result<Vec<CharacterMarketOrder>, Error>
+        url = "{}/characters/{}/orders";
+        label = "open market orders";
+        required_scopes = ScopeBuilder::new().market(MarketScopes::new().read_character_orders()).build();
+    }
+
+    define_endpoint! {
+        /// Fetches list of cancelled & expired market orders for the provided character ID up to 90 days in the past
+        ///
+        /// For an overview & usage examples, see the [endpoints module documentation](super)
+        ///
+        /// # ESI Documentation
+        /// - <https://developers.eveonline.com/api-explorer#/operations/GetCharactersCharacterIdOrdersHistory>
+        ///
+        /// # Required Scopes
+        /// - [`MarketScopes::read_character_orders`](crate::scope::MarketScopes::read_character_orders):
+        ///   `esi-markets.read_character_orders.v1`
+        ///
+        /// # Arguments
+        /// - `access_token`   (`&str`): Access token used for authenticated ESI routes in string format.
+        /// - `character_id`    (`i64`): The ID of the character to retrieve historical market orders for
+        /// - `page`            (`i32`): The page of market orders to retrieve, page numbers start at `1`
+        ///
+        /// # Returns
+        /// Returns a [`Result`] containing either:
+        /// - `Vec<`[`CharacterMarketOrder`]`>`: List of historical market orders for the provided character ID
+        /// - [`Error`]: An error if the fetch request fails
+        auth_get list_historical_orders_by_a_character(
+            access_token: &str,
+            character_id: i64,
+            page: i32,
+        ) -> Result<Vec<CharacterMarketOrder>, Error>
+        url = "{}/characters/{}/orders/history?page={}";
+        label = "historical orders";
+        required_scopes = ScopeBuilder::new().market(MarketScopes::new().read_character_orders()).build();
+    }
+
+    define_endpoint! {
+        /// Fetches list of open market orders for the provided corporation ID
+        ///
+        /// Additional permissions required: the owner of the access token must hold the `Accountant` or
+        /// `Trader` role within the corporation to access this information.
+        ///
+        /// For an overview & usage examples, see the [endpoints module documentation](super)
+        ///
+        /// # ESI Documentation
+        /// - <https://developers.eveonline.com/api-explorer#/operations/GetCorporationsCorporationIdOrders>
+        ///
+        /// # Required Scopes
+        /// - [`MarketScopes::read_corporation_orders`](crate::scope::MarketScopes::read_corporation_orders):
+        ///   `esi-markets.read_corporation_orders.v1`
+        ///
+        /// # Arguments
+        /// - `access_token`   (`&str`): Access token used for authenticated ESI routes in string format.
+        /// - `corporation_id`  (`i64`): The ID of the corporation to retrieve open market orders for
+        ///
+        /// # Returns
+        /// Returns a [`Result`] containing either:
+        /// - `Vec<`[`CorporationMarketOrder`]`>`: List of open market orders for the provided corporation ID
+        /// - [`Error`]: An error if the fetch request fails
+        auth_get list_open_orders_from_a_corporation(
+            access_token: &str,
+            corporation_id: i64
+        ) -> Result<Vec<CorporationMarketOrder>, Error>
+        url = "{}/corporations/{}/orders";
+        label = "open orders";
+        required_scopes = ScopeBuilder::new().market(MarketScopes::new().read_corporation_orders()).build();
+    }
+
+    define_endpoint! {
+        /// Fetches list of cancelled & expired market orders for the provided corporation ID up to 90 days in the past
+        ///
+        /// Additional permissions required: the owner of the access token must hold the `Accountant` or
+        /// `Trader` role within the corporation to access this information.
+        ///
+        /// For an overview & usage examples, see the [endpoints module documentation](super)
+        ///
+        /// # ESI Documentation
+        /// - <https://developers.eveonline.com/api-explorer#/operations/GetCorporationsCorporationIdOrdersHistory>
+        ///
+        /// # Required Scopes
+        /// - [`MarketScopes::read_corporation_orders`](crate::scope::MarketScopes::read_corporation_orders):
+        ///   `esi-markets.read_corporation_orders.v1`
+        ///
+        /// # Arguments
+        /// - `access_token`   (`&str`): Access token used for authenticated ESI routes in string format.
+        /// - `corporation_id`  (`i64`): The ID of the corporation to retrieve historical market orders for
+        /// - `page`            (`i32`): The page of market orders to retrieve, page numbers start at `1`
+        ///
+        /// # Returns
+        /// Returns a [`Result`] containing either:
+        /// - `Vec<`[`CorporationMarketOrder`]`>`: List of historical market orders for the provided corporation ID
+        /// - [`Error`]: An error if the fetch request fails
+        auth_get list_historical_orders_from_a_corporation(
+            access_token: &str,
+            corporation_d: i64,
+            page: i32,
+        ) -> Result<Vec<CorporationMarketOrder>, Error>
+        url = "{}/corporations/{}/orders/history?page={}";
+        label = "historical orders";
+        required_scopes = ScopeBuilder::new().market(MarketScopes::new().read_corporation_orders()).build();
+    }
+
+    define_endpoint! {
+        /// Retrieves a list of IDs of market item groups
+        ///
+        /// For an overview & usage examples, see the [endpoints module documentation](super)
+        ///
+        /// # ESI Documentation
+        /// - <https://developers.eveonline.com/api-explorer#/operations/GetMarketsGroups>
+        ///
+        /// # Returns
+        /// Returns a [`Result`] containing either:
+        /// - `Vec<i64>`: List of IDs of market item groups
+        /// - [`Error`]: An error if the fetch request fails
+        pub_get get_item_groups(
+        ) -> Result<Vec<i64>, Error>
+        url = "{}/markets/groups";
+        label = "market groups";
+    }
+
+    define_endpoint! {
+        /// Retrieves the information of the provided market item group ID
+        ///
+        /// For an overview & usage examples, see the [endpoints module documentation](super)
+        ///
+        /// # ESI Documentation
+        /// - <https://developers.eveonline.com/api-explorer#/operations/GetMarketsGroupsMarketGroupId>
+        ///
+        /// # Arguments
+        /// - `market_group_id` (`i64`): The ID of the market group to retrieve information for.
+        ///
+        /// # Returns
+        /// Returns a [`Result`] containing either:
+        /// - `Vec<`[`MarketItemGroupInformation`]`>`: The information of the provided market item group ID
+        /// - [`Error`]: An error if the fetch request fails
+        pub_get get_item_group_information(
+            market_group_id: i64
+        ) -> Result<MarketItemGroupInformation, Error>
+        url = "{}/markets/groups/{}";
+        label = "market item group information";
+    }
+
+    define_endpoint! {
+        /// Retrieves the average & adjusted market prices of all items
+        ///
+        /// For an overview & usage examples, see the [endpoints module documentation](super)
+        ///
+        /// # ESI Documentation
+        /// - <https://developers.eveonline.com/api-explorer#/operations/GetMarketsPrices>
+        ///
+        /// # Returns
+        /// Returns a [`Result`] containing either:
+        /// - `Vec<`[`MarketItemPrices`]`>`: The average & adjusted market prices of all items
+        /// - [`Error`]: An error if the fetch request fails
+        pub_get list_market_prices(
+        ) -> Result<Vec<MarketItemPrices>, Error>
+        url = "{}/markets/prices";
+        label = "market item prices";
+    }
+
+    define_endpoint! {
+        /// Fetches list of market orders for the provided structure ID
+        ///
+        /// For an overview & usage examples, see the [endpoints module documentation](super)
+        ///
+        /// # ESI Documentation
+        /// - <https://developers.eveonline.com/api-explorer#/operations/GetCorporationsCorporationIdOrdersHistory>
+        ///
+        /// # Required Scopes
+        /// - [`MarketScopes::structure_markets`](crate::scope::MarketScopes::structure_markets):
+        ///   `esi-markets.structure_markets.v1`
+        ///
+        /// # Arguments
+        /// - `access_token`   (`&str`): Access token used for authenticated ESI routes in string format.
+        /// - `corporation_id`  (`i64`): The ID of the structure to retrieve market orders for
+        /// - `page`            (`i32`): The page of market orders to retrieve, page numbers start at `1`
+        ///
+        /// # Returns
+        /// Returns a [`Result`] containing either:
+        /// - `Vec<`[`StructureMarketOrder`]`>`: List of market orders for the provided structure ID
+        /// - [`Error`]: An error if the fetch request fails
+        auth_get list_orders_in_a_structure(
+            access_token: &str,
+            structure_id: i64,
+            page: i32,
+        ) -> Result<Vec<StructureMarketOrder>, Error>
+        url = "{}/markets/structures/{}?page={}";
+        label = "market orders";
+        required_scopes = ScopeBuilder::new().market(MarketScopes::new().structure_markets()).build();
+    }
+
+    define_endpoint! {
+        /// Retrieves list of entries with historical market statistics for the provided item type ID in provided region ID
+        ///
+        /// For an overview & usage examples, see the [endpoints module documentation](super)
+        ///
+        /// # ESI Documentation
+        /// - <https://developers.eveonline.com/api-explorer#/operations/GetMarketsRegionIdHistory>
+        ///
+        /// # Arguments
+        /// - `region_id` (`i64`): ID of the region to retrieve market statistics for the specified item type ID
+        /// - `type_id`   (`i64`): ID of the item type to retrieve market statistics for in the specified region ID
+        ///
+        /// # Returns
+        /// Returns a [`Result`] containing either:
+        /// - `Vec<`[`MarketItemRegionStatistics`]`>`: List of entries with historical market statistics for the provided item type ID in provided region ID
+        /// - [`Error`]: An error if the fetch request fails
+        pub_get list_historical_market_statistics_in_a_region(
+            region_id: i64,
+            type_id: i64
+        ) -> Result<Vec<MarketItemRegionStatistics>, Error>
+        url = "{}/markets/{}/history?type_id={}";
+        label = "regional market statistics for item";
+    }
+
+    define_endpoint! {
+        /// Retrieves a list of market orders within the provided region ID and of the specified order type
+        ///
+        /// For an overview & usage examples, see the [endpoints module documentation](super)
+        ///
+        /// # ESI Documentation
+        /// - <https://developers.eveonline.com/api-explorer#/operations/GetMarketsRegionIdHistory>
+        ///
+        /// # Arguments
+        /// - `region_id`   (`i64`): ID of the region to retrieve market orders for
+        /// - `order_type`  ([`OrderType`]): Enum representing type of market order to request, either [`OrderType::Sell`],
+        ///   [`OrderType::Buy`], or [`OrderType::All`] for both
+        /// - `page`            (`i32`): The page of market orders to retrieve, page numbers start at `1`
+        ///
+        /// # Returns
+        /// Returns a [`Result`] containing either:
+        /// - `Vec<`[`MarketRegionOrder`]`>`: list of market orders within the provided region ID and of the specified order type
+        pub_get list_orders_in_a_region(
+            region_id: i64,
+            order_type: OrderType,
+            page: i32
+        ) -> Result<Vec<MarketRegionOrder>, Error>
+        url = "{}/markets/{}/orders?order_type={}&page={}";
+        label = "market orders";
+    }
+
+    define_endpoint! {
+        /// Retrieves a list of type IDs that have active market orders for the given region ID
+        ///
+        /// For an overview & usage examples, see the [endpoints module documentation](super)
+        ///
+        /// # ESI Documentation
+        /// - <https://developers.eveonline.com/api-explorer#/operations/GetMarketsRegionIdTypes>
+        ///
+        /// # Arguments
+        /// - `region_id`   (`i64`): ID of the region to retrieve item type IDs for
+        /// - `page`        (`i32`): The page of market orders to retrieve, page numbers start at `1`
+        ///
+        /// # Returns
+        /// Returns a [`Result`] containing either:
+        /// - `Vec<i64>`: list of type IDs that have active market orders for the given region ID
+        pub_get list_type_ids_relevant_to_a_market(
+            region_id: i64,
+            page: i32
+        ) -> Result<Vec<i64>, Error>
+        url = "{}/markets/{}/types?page={}";
+        label = "item type IDs with active market orders";
+    }
+}

--- a/src/endpoints/mod.rs
+++ b/src/endpoints/mod.rs
@@ -3,9 +3,10 @@
 //! This module provides access to the different categories of endpoints available for EVE Online's ESI API.
 //!
 //! ## Modules
-//! - [`alliance`]: Alliance endpoints
-//! - [`character`]: Character endpoints
-//! - [`corporation`]: Corporation endpoints
+//! - [`alliance`]: Alliance endpoints (4/4 endpoints)
+//! - [`character`]: Character endpoints (11/11 endpoints)
+//! - [`corporation`]: Corporation endpoints (22/22 endpoints)
+//! - [`market`]: Market endpoints (11/11 endpoints)
 //!
 //! ## ESI Documentation
 //! - ESI API Explorer: <https://developers.eveonline.com/api-explorer>
@@ -75,8 +76,9 @@ mod macros;
 pub mod alliance;
 pub mod character;
 pub mod corporation;
+pub mod market;
 
-use crate::Client;
+use crate::{endpoints::market::MarketEndpoints, Client};
 
 use alliance::AllianceApi;
 use character::CharacterApi;
@@ -108,5 +110,12 @@ impl Client {
     /// Returns an API client for interacting with corporation-related endpoints.
     pub fn corporation(&self) -> CorporationApi<'_> {
         CorporationApi::new(self)
+    }
+
+    /// Access to market ESI endpoints
+    ///
+    /// For an overview & usage example, see the [endpoints module documentation](super)
+    pub fn market(&self) -> MarketEndpoints<'_> {
+        MarketEndpoints::new(self)
     }
 }

--- a/src/esi/mod.rs
+++ b/src/esi/mod.rs
@@ -12,7 +12,6 @@
 //! [endpoints module documentation](crate::endpoints)
 //!
 //! ## Modules
-//! - [`esi`]: Provides the [`EsiApi`] struct implementing request methods on the [`crate::Client`]
 //! - [`public`]: Methods for making public requests to ESI endpoints
 //! - [`authenticated`]: Methods for making authenticated requests to ESI endpoints using an access token
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //!
 //! ### Single Sign-On (OAuth2)
 //!
-//! - [Building scopes to request during login](crate::oauth2::scope)
+//! - [Building scopes to request during login](crate::scope)
 //! - [Creating a login URL for single sign-on (OAuth2)](crate::oauth2::login)
 //! - [Fetching an access token](crate::oauth2::token)
 //! - [Validating an access token](crate::oauth2::token)
@@ -104,13 +104,14 @@ pub mod error;
 pub mod esi;
 pub mod model;
 pub mod oauth2;
+pub mod scope;
 
 pub use crate::builder::ClientBuilder;
 pub use crate::client::Client;
 pub use crate::config::{Config, ConfigBuilder};
 pub use crate::error::{ConfigError, Error};
 pub use crate::oauth2::error::OAuthError;
-pub use crate::oauth2::ScopeBuilder;
+pub use crate::scope::ScopeBuilder;
 
 mod constant;
 

--- a/src/model/alliance.rs
+++ b/src/model/alliance.rs
@@ -1,13 +1,18 @@
-//! Data structures and types for representing alliances in EVE Online.
+//! # EVE ESI Alliance Models
 //!
 //! This module defines the `Alliance` struct, which models the core properties of an alliance in EVE Online.
 //!
-//! See [ESI API documentation](https://developers.eveonline.com/api-explorer)
+//! ## ESI Documentation
+//! - <https://developers.eveonline.com/api-explorer>
+//!
+//! ## Models
+//! - [`Alliance`]: Represents an alliance in EVE Online.
+//! - [`AllianceIcons`]: Represents the 128x128 & 64x64 icon URLs for an alliance
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
-/// Represents an alliance in EVE Online.
+/// Represents an alliance in EVE Online
 ///
 /// # Documentation
 /// - <https://developers.eveonline.com/api-explorer#/schemas/AlliancesAllianceIdGet>

--- a/src/model/character.rs
+++ b/src/model/character.rs
@@ -1,9 +1,24 @@
-//! Data structures and types for representing characters in EVE Online.
+//! # EVE ESI Character Models
 //!
 //! This module defines the `Character` & `CharacterAffiliation` structs,
 //! which model the core properties of a character & character affiliation in EVE Online.
 //!
-//! See [ESI API documentation](https://developers.eveonline.com/api-explorer#/schemas/CharactersCharacterIdGet)
+//! ## ESI Documentation
+//! - <https://developers.eveonline.com/api-explorer>
+//!
+//! ## Models
+//! - [`Character`]: Represents a character in EVE Online
+//! - [`CharacterAffiliation`]: Represents the affiliations of a character in EVE Online
+//! - [`CharacterResearchAgent`]: Information regarding a character's research agent
+//! - [`CharacterCorporationHistory`]: Represents a character's corporation history
+//! - [`CharacterJumpFatigue`]: Represents a character's jump fatigue status
+//! - [`CharacterMedalGraphics`]: Represents the graphics configuration for a character's medal
+//! - [`CharacterMedal`]: Represents an entry for a character's medals
+//! - [`CharacterNotification`]: Represents a character notification entry
+//! - [`CharacterNewContactNotification`]: Notification when character has been added to someone's contact list
+//! - [`CharacterPortraits`]: A character's portrait URLs with various dimensions
+//! - [`CharacterCorporationRole`]: A character's portrait URLs with various dimensions
+//! - [`CharacterCorporationTitle`]: An entry for a character's corporation titles
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -14,7 +29,7 @@ use crate::model::enums::{
     notification::{NotificationSenderType, NotificationType},
 };
 
-/// Represents a character in EVE Online.
+/// Represents a character in EVE Online
 ///
 /// # Documentation
 /// - <https://developers.eveonline.com/api-explorer#/schemas/CharactersCharacterIdGet>
@@ -44,7 +59,7 @@ pub struct Character {
     pub title: Option<String>,
 }
 
-/// Represents the affiliations of a character in EVE Online.
+/// Represents the affiliations of a character in EVE Online
 ///
 /// # Documentation
 /// - <https://developers.eveonline.com/api-explorer#/schemas/CharactersAffiliationPost>

--- a/src/model/corporation.rs
+++ b/src/model/corporation.rs
@@ -1,8 +1,31 @@
-//! Data structures and types for representing corporations in EVE Online.
+//! # EVE ESI Corporation Models
 //!
 //! This module defines the `Corporation` struct, which models the core properties of a corporation in EVE Online.
 //!
-//! See [ESI API documentation](https://developers.eveonline.com/api-explorer#/schemas/CorporationsCorporationIdGet)
+//! ## ESI Documentation
+//! - <https://developers.eveonline.com/api-explorer>
+//!
+//! ## Models
+//! - [`Corporation`]: Represents a corporation in EVE Online
+//! - [`CorporationAllianceHistory`]: Entry for a corporation's alliance history
+//! - [`CorporationSecureContainerLog`]: Log entry for an audit log secure container owned by a corporation
+//! - [`CorporationDivisionEntry`]: An entry for a corporation's hangar or wallet division
+//! - [`CorporationDivisions`]: Lists of a corporation wallet and hangar divisions
+//! - [`CorporationFacilities`]: Entry for corporation industry facilities
+//! - [`CorporationIcon`]: Icon URLs for a corporation
+//! - [`CorporationMedal`]: An entry for a corporation medal
+//! - [`CorporationIssuedMedal`]: An entry for an issued corporation medal
+//! - [`CorporationMemberTitles`]: An entry for a corporation member's titles
+//! - [`CorporationMemberTracking`]: An entry for a corporation member's tracking information
+//! - [`CorporationMemberRoles`]: An entry for a corporation member's assigned roles
+//! - [`CorporationMemberRolesHistory`]: An entry for a corporation member's role history
+//! - [`CorporationShareholder`]: An entry for a corporation shareholder
+//! - [`CorporationStarbase`]: Information regarding a starbase (POS) owned by a corporation
+//! - [`CorporationStarbaseFuel`]: Entry on the fuel types stored within a corporation starbase (POS)
+//! - [`CorporationStarbaseDetails`]: Information regarding a starbase's (POS) details owned by a corporation
+//! - [`CorporationStructureService`]: An entry for a corporation's Upwell structure services
+//! - [`CorporationStructure`]: Details regarding a corporation's Upwell structure
+//! - [`CorporationTitle`]: An entry for a corporation's titles and its respective roles
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -17,7 +40,7 @@ use crate::model::enums::{
     },
 };
 
-/// Represents a corporation in EVE Online.
+/// Represents a corporation in EVE Online
 ///
 /// # Documentation
 /// - <https://developers.eveonline.com/api-explorer#/schemas/CorporationsCorporationIdGet>
@@ -100,7 +123,7 @@ pub struct CorporationSecureContainerLog {
     pub type_id: i64,
 }
 
-/// Log entry for an audit log secure container owned by a corporation
+/// An entry for a corporation's hangar or wallet division
 ///
 /// # Documentation
 /// - <https://developers.eveonline.com/api-explorer#/schemas/CorporationsCorporationIdDivisionsGet>
@@ -112,7 +135,7 @@ pub struct CorporationDivisionEntry {
     pub name: Option<String>,
 }
 
-/// Log entry for an audit log secure container owned by a corporation
+/// Lists of a corporation wallet and hangar divisions
 ///
 /// # Documentation
 /// - <https://developers.eveonline.com/api-explorer#/schemas/CorporationsCorporationIdDivisionsGet>
@@ -328,7 +351,7 @@ pub struct CorporationStarbase {
 /// # ESI Documentation
 /// - <https://developers.eveonline.com/api-explorer#/schemas/CorporationsCorporationIdStarbasesStarbaseIdGet>
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
-pub struct StarbaseFuel {
+pub struct CorporationStarbaseFuel {
     /// The quantity of fuel stored in the starbase (POS)
     pub quantity: i64,
     /// The type ID of the fuel stored within the starbase (POS)
@@ -360,7 +383,7 @@ pub struct CorporationStarbaseDetails {
     /// Enum indicating who has permission to view POS fuel bay
     pub fuel_bay_view: CorporationStarbasePermission,
     /// List of entries containing type_id of fuel and quantity stored within the POS
-    pub fuels: Vec<StarbaseFuel>,
+    pub fuels: Vec<CorporationStarbaseFuel>,
     /// Enum indicating who has permission to offline POS and its structures
     pub offline: CorporationStarbasePermission,
     /// Enum indicating who has permission to online POS and its structures

--- a/src/model/enums/corporation.rs
+++ b/src/model/enums/corporation.rs
@@ -3,7 +3,14 @@
 //! Provides enums related to corporations in EVE Online
 //!
 //! ## Enums
+//! - [`CorporationRoleType`]: Indicates the type & location of the corporation role
 //! - [`CorporationRole`]: Indicates the type of corporation role
+//! - [`CorporationSecureContainerAction`]: Indicates the type of action on an audit log secure container log entry
+//! - [`ShareholderType`]: Indicates whether shares are held by a character or corporation
+//! - [`CorporationStarbaseState`]: Indicates the current state of a corporation starbase (POS)
+//! - [`CorporationStarbasePermission`]: The permission required to perform an action on a corporation owned starbase (POS)
+//! - [`CorporationStructureServiceState`]: The possible states of a corporation's Upwell structure's service module
+//! - [`CorporationStructureState`]: The possible states of a corporation's Upwell structure
 
 use serde::{Deserialize, Serialize};
 

--- a/src/model/enums/market.rs
+++ b/src/model/enums/market.rs
@@ -1,0 +1,124 @@
+//! # EVE ESI Market Enums
+//!
+//! Provides enums related to markets in EVE Online
+//!
+//! ## Enums
+//! - [`MarketOrderRange`]: Indicates the the range of a market order
+//! - [`HistoricalMarketOrderState`]: Indicates whether a historical market order expired or was cancelled
+//! - [`OrderType`]: Represents the type of order when requesting a list of orders within a region
+
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+/// Indicates the the range of a market order
+///
+/// # Documentation
+/// - <https://developers.eveonline.com/api-explorer#/schemas/CharactersCharacterIdOrdersGet>
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub enum MarketOrderRange {
+    /// Market order has a range of within 1 jump
+    #[serde(rename = "1")]
+    OneJump,
+    /// Market order has a range of within 2 jumps
+    #[serde(rename = "2")]
+    TwoJumps,
+    /// Market order has a range of within 3 jumps
+    #[serde(rename = "3")]
+    ThreeJumps,
+    /// Market order has a range of within 4 jumps
+    #[serde(rename = "4")]
+    FourJumps,
+    /// Market order has a range of within 5 jumps
+    #[serde(rename = "5")]
+    FiveJumps,
+    /// Market order has a range of within 10 jumps
+    #[serde(rename = "10")]
+    TenJumps,
+    /// Market order has a range of within 20 jumps
+    #[serde(rename = "20")]
+    TwentyJumps,
+    /// Market order has a range of within 30 jumps
+    #[serde(rename = "30")]
+    ThirtyJumps,
+    /// Market order has a range of within 40 jumps
+    #[serde(rename = "40")]
+    FourtyJumps,
+    /// Market order has a range of within its current region
+    #[serde(rename = "region")]
+    Region,
+    /// Market order has a range of within its current system
+    #[serde(rename = "solarsystem")]
+    SolarSystem,
+    /// Market order has a range of within its current station
+    #[serde(rename = "station")]
+    Station,
+}
+
+/// Indicates whether a historical market order expired or was cancelled
+///
+/// # Documentation
+/// - <https://developers.eveonline.com/api-explorer#/schemas/CharactersCharacterIdOrdersHistoryGet>
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub enum HistoricalMarketOrderState {
+    /// Market order was cancelled
+    #[serde(rename = "cancelled")]
+    Cancelled,
+    /// Market order has expired
+    #[serde(rename = "expired")]
+    Expired,
+}
+
+/// Represents the type of order when requesting a list of orders within a region
+///
+/// # Documentation
+/// - <https://developers.eveonline.com/api-explorer#/operations/GetMarketsRegionIdOrders>
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub enum OrderType {
+    /// Request only buy orders
+    #[serde(rename = "buy")]
+    Buy,
+    /// Request only sell orders
+    #[serde(rename = "sell")]
+    Sell,
+    /// Request both buy & sell orders
+    #[serde(rename = "all")]
+    All,
+}
+
+// Required for ESI endpoint macro URL formatting
+//
+// This enum is used as an argument when requesting market orders within a region
+impl fmt::Display for OrderType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            OrderType::Buy => "buy",
+            OrderType::Sell => "sell",
+            OrderType::All => "all",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+#[cfg(test)]
+mod market_enum_tests {
+    use crate::model::enums::market::OrderType;
+
+    /// Ensures [`OrderType`] displays as string "buy"
+    #[test]
+    fn test_order_type_buy_display() {
+        assert_eq!(OrderType::Buy.to_string(), "buy")
+    }
+
+    /// Ensures [`OrderType`] displays as string "sell"
+    #[test]
+    fn test_order_type_sell_display() {
+        assert_eq!(OrderType::Sell.to_string(), "sell")
+    }
+
+    /// Ensures [`OrderType`] displays as string "all"
+    #[test]
+    fn test_order_type_all_display() {
+        assert_eq!(OrderType::All.to_string(), "all")
+    }
+}

--- a/src/model/enums/mod.rs
+++ b/src/model/enums/mod.rs
@@ -11,5 +11,6 @@
 pub mod asset;
 pub mod character;
 pub mod corporation;
+pub mod market;
 pub mod notification;
-pub mod universe;
+pub mod standing;

--- a/src/model/enums/standing.rs
+++ b/src/model/enums/standing.rs
@@ -1,6 +1,9 @@
-//! # EVE ESI Universe Enums
+//! # EVE ESI Standing Enums
 //!
-//! Provides enums shared between entities for EVE Online
+//! Provides standing enum shared between characters & corporations
+//!
+//! ## Enums
+//! - [`StandingType`]: The type of character or corporation standing entry (Agent, NpcCorp, or Faction)
 
 use serde::{Deserialize, Serialize};
 

--- a/src/model/market.rs
+++ b/src/model/market.rs
@@ -1,0 +1,227 @@
+//! # EVE ESI Market Models
+//!
+//! Provides models related to market endpoints for EVE Online's ESI API.
+//!
+//! ## ESI Documentation
+//! - <https://developers.eveonline.com/api-explorer>
+//!
+//! ## Models
+//! - [`CharacterMarketOrder`]: Details for a character's market order
+//! - [`CorporationMarketOrder`]: Details for a corporation's market order
+//! - [`MarketItemGroupInformation`]: Information regarding a specific market group
+//! - [`MarketItemPrices`]: The average & adjusted market prices of an item
+//! - [`StructureMarketOrder`]: Details for a market order placed within a structure
+//! - [`MarketItemRegionStatistics`]: An entry for the market statistics of an item within a specific region on a given date
+
+use chrono::{DateTime, NaiveDate, Utc};
+use serde::{Deserialize, Serialize};
+
+use crate::model::enums::market::{HistoricalMarketOrderState, MarketOrderRange};
+
+/// Details for a character's market order
+///
+/// # Documentation
+/// - <https://developers.eveonline.com/api-explorer#/schemas/CharactersCharacterIdOrdersGet>
+/// - <https://developers.eveonline.com/api-explorer#/schemas/CharactersCharacterIdOrdersHistoryGet>
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct CharacterMarketOrder {
+    /// Number of days for which the order is valid
+    /// starting from the issued date.
+    ///
+    /// An order expires at time issued + duration
+    pub duration: i64,
+    /// For buy orders, the amount of ISK in escrow
+    pub escrow: Option<f64>,
+    /// True if the order is a buy order
+    #[serde(default)]
+    pub is_buy_order: bool,
+    /// Indicates whether or not order was placed on behalf of a corporation
+    pub is_corporation: bool,
+    /// Date and time when the order was issued
+    pub issued: DateTime<Utc>,
+    /// ID of the location where order was placed
+    pub location_id: i64,
+    /// For buy orders, the minimum quantity that will be accepted in a matching sell order
+    pub min_volume: Option<i64>,
+    /// Unique ID of the order
+    pub order_id: i64,
+    /// The cost per unit for this order
+    pub price: f64,
+    /// The range of the order
+    pub range: MarketOrderRange,
+    /// ID of the region where the order was placed
+    pub region_id: i64,
+    /// If it is a historical market order, indicates whether it was cancelled or expired
+    pub state: Option<HistoricalMarketOrderState>,
+    /// The type ID of the item in the order
+    pub type_id: i64,
+    /// Remaining quantity of items still for sale or buy
+    pub volume_remain: i64,
+    /// Quantity of items for sale or to buy when the order was placed
+    pub volume_total: i64,
+}
+
+/// Details for a corporation's market order
+///
+/// # Documentation
+/// - <https://developers.eveonline.com/api-explorer#/schemas/CorporationsCorporationIdOrdersGet>
+/// - <https://developers.eveonline.com/api-explorer#/schemas/CorporationsCorporationIdOrdersHistoryGet>
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct CorporationMarketOrder {
+    /// Number of days for which the order is valid
+    /// starting from the issued date.
+    ///
+    /// An order expires at time issued + duration
+    pub duration: i64,
+    /// For buy orders, the amount of ISK in escrow
+    pub escrow: Option<f64>,
+    /// True if the order is a buy order
+    #[serde(default)]
+    pub is_buy_order: bool,
+    /// Date and time when the order was issued
+    pub issued: DateTime<Utc>,
+    /// Character ID of who issued the market order
+    pub issued_by: i64,
+    /// ID of the location where order was placed
+    pub location_id: i64,
+    /// For buy orders, the minimum quantity that will be accepted in a matching sell order
+    pub min_volume: Option<i64>,
+    /// Unique ID of the order
+    pub order_id: i64,
+    /// The cost per unit for this order
+    pub price: f64,
+    /// The range of the order
+    pub range: MarketOrderRange,
+    /// ID of the region where the order was placed
+    pub region_id: i64,
+    /// If it is a historical market order, indicates whether it was cancelled or expired
+    pub state: Option<HistoricalMarketOrderState>,
+    /// The type ID of the item in the order
+    pub type_id: i64,
+    /// Remaining quantity of items still for sale or buy
+    pub volume_remain: i64,
+    /// Quantity of items for sale or to buy when the order was placed
+    pub volume_total: i64,
+}
+
+/// Information regarding a specific market group
+///
+/// # Documentation
+/// - <https://developers.eveonline.com/api-explorer#/schemas/MarketsGroupsMarketGroupIdGet>
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct MarketItemGroupInformation {
+    /// The description of the market item group
+    pub description: String,
+    /// The name of the market item group
+    pub name: String,
+    /// The ID of the market item group
+    pub market_group_id: i64,
+    /// The ID of the parent market item group if applicable
+    pub parent_group_id: Option<i64>,
+    /// The type IDs of the items within the group
+    pub types: Vec<i64>,
+}
+
+/// The average & adjusted market prices of an item
+///
+/// # Documentation
+/// - <https://developers.eveonline.com/api-explorer#/schemas/MarketsPricesGet>
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct MarketItemPrices {
+    /// The estimated price of what the item actually sells for on the market
+    pub adjusted_price: Option<f64>,
+    /// The average price of the item on the market
+    pub average_price: Option<f64>,
+    /// The type ID of the item on the market
+    pub type_id: i64,
+}
+
+/// Details for a market order placed within a structure
+///
+/// # Documentation
+/// - <https://developers.eveonline.com/api-explorer#/schemas/MarketsStructuresStructureIdGet>
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct StructureMarketOrder {
+    /// Number of days for which the order is valid
+    /// starting from the issued date.
+    ///
+    /// An order expires at time issued + duration
+    pub duration: i64,
+    /// True if the order is a buy order
+    #[serde(default)]
+    pub is_buy_order: bool,
+    /// Date and time when the order was issued
+    pub issued: DateTime<Utc>,
+    /// ID of the location where order was placed
+    pub location_id: i64,
+    /// For buy orders, the minimum quantity that will be accepted in a matching sell order
+    pub min_volume: Option<i64>,
+    /// Unique ID of the order
+    pub order_id: i64,
+    /// The cost per unit for this order
+    pub price: f64,
+    /// The range of the order
+    pub range: MarketOrderRange,
+    /// The type ID of the item in the order
+    pub type_id: i64,
+    /// Remaining quantity of items still for sale or buy
+    pub volume_remain: i64,
+    /// Quantity of items for sale or to buy when the order was placed
+    pub volume_total: i64,
+}
+
+/// An entry for the market statistics of an item within a specific region on a given date
+///
+/// # Documentation
+/// - <https://developers.eveonline.com/api-explorer#/schemas/MarketsRegionIdHistoryGet>
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct MarketItemRegionStatistics {
+    /// The average price of the item in this entry
+    pub average: f64,
+    /// The YYYY-MM-DD of this statistic entry
+    pub date: NaiveDate,
+    /// The highest price the item sold for in this entry
+    pub highest: f64,
+    /// The lowest price the item sold for in this enry
+    pub lowest: f64,
+    /// Total numbers of orders that occurred for this entry
+    pub order_count: i64,
+    /// The volume of the item traded for this entry
+    pub volume: i64,
+}
+
+/// Entry for a market order placed when requesting regional market orders
+///
+/// # Documentation
+/// - <https://developers.eveonline.com/api-explorer#/schemas/MarketsRegionIdOrdersGet>
+#[derive(Serialize, Deserialize, Debug, PartialEq)]
+pub struct MarketRegionOrder {
+    /// Number of days for which the order is valid
+    /// starting from the issued date.
+    ///
+    /// An order expires at time issued + duration
+    pub duration: i64,
+    /// True if the order is a buy order
+    #[serde(default)]
+    pub is_buy_order: bool,
+    /// Date and time when the order was issued
+    pub issued: DateTime<Utc>,
+    /// ID of the location where order was placed
+    pub location_id: i64,
+    /// For buy orders, the minimum quantity that will be accepted in a matching sell order
+    pub min_volume: i64,
+    /// Unique ID of the order
+    pub order_id: i64,
+    /// The cost per unit for this order
+    pub price: f64,
+    /// The range of the order
+    pub range: MarketOrderRange,
+    /// ID of the solar system where the order was placed
+    pub system_id: i64,
+    /// The type ID of the item in the order
+    pub type_id: i64,
+    /// Remaining quantity of items still for sale or buy
+    pub volume_remain: i64,
+    /// Quantity of items for sale or to buy when the order was placed
+    pub volume_total: i64,
+}

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -22,5 +22,6 @@ pub mod asset;
 pub mod character;
 pub mod corporation;
 pub mod enums;
+pub mod market;
 pub mod oauth2;
-pub mod universe;
+pub mod standing;

--- a/src/model/standing.rs
+++ b/src/model/standing.rs
@@ -1,10 +1,10 @@
-//! # EVE ESI Universe Models
+//! # EVE ESI Standing Models
 //!
-//! This module defines models shared between entities in EVE Online
+//! This module define the [`Standing`] model shared between characters & corporations
 
 use serde::{Deserialize, Serialize};
 
-use crate::model::enums::universe::StandingType;
+use crate::model::enums::standing::StandingType;
 
 /// A character or corporation's standings with either an agent, NPC corp, or faction
 ///

--- a/src/oauth2/login.rs
+++ b/src/oauth2/login.rs
@@ -98,7 +98,7 @@ impl<'a> OAuth2Api<'a> {
 #[cfg(test)]
 mod tests {
     use crate::error::{Error, OAuthError};
-    use crate::oauth2::ScopeBuilder;
+    use crate::ScopeBuilder;
 
     /// Tests the successful generation of an OAuth2 login URL and CSRF state token.
     ///

--- a/src/oauth2/mod.rs
+++ b/src/oauth2/mod.rs
@@ -13,17 +13,20 @@
 //!
 //! - [`login`]: Methods to begin the OAuth2 login process
 //! - [`token`]: Methods to retrieve, validate, & refresh OAuth2 tokens
-//! - [`scope`]: Builder to create scopes to request during the login process
 //! - [`jwk`]: Methods to handle JSON web keys used to validate authentication tokens
 //! - [`error`]: Error enum for any OAuth2 related errors.
+//!
+//! ## Usage Examples
+//!
+//! - [Creating a login URL for single sign-on (OAuth2)](crate::oauth2::login)
+//! - [Fetching an access token](crate::oauth2::token)
+//! - [Validating an access token](crate::oauth2::token)
+//! - [Refreshing an access token](crate::oauth2::token)
 
 pub mod error;
 pub mod jwk;
 pub mod login;
-pub mod scope;
 pub mod token;
-
-pub use scope::ScopeBuilder;
 
 pub(crate) mod client;
 

--- a/src/scope/builder.rs
+++ b/src/scope/builder.rs
@@ -1,18 +1,21 @@
-//! # EVE Online OAuth2 Scope Builder
+//! # EVE ESI Scope Builder
 //!
 //! This module provides a type-safe way to define and manage EVE Online ESI OAuth2 scopes
 //! using the [`ScopeBuilder`].
 //!
+//! For an overview & usage, see the [module-level documentation](super).
+//!
 //! # Methods
 //! - [`ScopeBuilder::new`]: Creates a new [`ScopeBuilder`] instance
 //! - [`ScopeBuilder::build`]: Builds the list of scopes into a `Vec<`[`String`]`>`
-//! - [`ScopeBuilder::public_data`]: Adds the `publicData` scope
+//! - [`ScopeBuilder::public_data`]: Access to retrieve public information on a character (this scope is mostly just for show)
 //! - [`ScopeBuilder::character`]: Adds scopes from [`CharacterScopes`]
+//! - [`ScopeBuilder::corporation`]: Adds scopes from [`CorporationScopes`]
+//! - [`ScopeBuilder::wallet`]: Adds scopes from [`WalletScopes`]
+//! - [`ScopeBuilder::market`]: Adds scopes from [`MarketScopes`]
 //! - [`ScopeBuilder::custom`]: Adds a custom scope
-//!
-//! For an overview & usage, see the [module-level documentation](super).
 
-use crate::oauth2::scope::{CorporationScopes, WalletScopes};
+use crate::scope::{CorporationScopes, MarketScopes, WalletScopes};
 
 use super::character::CharacterScopes;
 
@@ -46,6 +49,7 @@ impl ScopeBuilder {
             .character(CharacterScopes::all())
             .corporation(CorporationScopes::all())
             .wallet(WalletScopes::all())
+            .market(MarketScopes::all())
             .build()
     }
 
@@ -54,6 +58,8 @@ impl ScopeBuilder {
         self.scopes
     }
 
+    /// Access to retrieve public information on a character (this scope is mostly just for show)
+    ///
     /// Adds the `publicData` scope
     pub fn public_data(mut self) -> Self {
         self.scopes.push(PUBLIC_DATA.to_string());
@@ -75,6 +81,12 @@ impl ScopeBuilder {
     /// Adds scopes from [`WalletScopes`]
     pub fn wallet(mut self, wallet_scopes: WalletScopes) -> Self {
         self.scopes.extend(wallet_scopes.scopes);
+        self
+    }
+
+    /// Adds scopes from [`MarketScopes`]
+    pub fn market(mut self, market_scopes: MarketScopes) -> Self {
+        self.scopes.extend(market_scopes.scopes);
         self
     }
 

--- a/src/scope/character.rs
+++ b/src/scope/character.rs
@@ -1,11 +1,21 @@
-//! # EVE Online OAuth2 Character Scopes
+//! # EVE ESI Character Scopes
 //!
 //! This module provides a type-safe way to add character-related scopes for OAuth2 to the [`super::ScopeBuilder`]
 //!
 //! See [module-level documentation](super) for an overview & usage of scopes for the esi_crate
 //!
-//! # Methods
-//! - [`CharacterScopes::read_agents_research`]: Adds the `esi-characters.read_agents_research.v1` scope
+//! ## Methods
+//! - [`CharacterScopes::new`]: Create a new instance of [`CharacterScopes`]
+//! - [`CharacterScopes::all`]: Creates a new instance of [`CharacterScopes`] with all scopes applied
+//! - [`CharacterScopes::read_agents_research`]: Access to retrieve information on character's research agents
+//! - [`CharacterScopes::read_blueprints`]: Access to retrieve information on character's blueprints
+//! - [`CharacterScopes::read_contacts`]: Access to read a character's contacts
+//! - [`CharacterScopes::read_fatigue`]: Access to retrieve information on character's jump fatigue status
+//! - [`CharacterScopes::read_medals`]: Access to retrieve information on character's medals
+//! - [`CharacterScopes::read_notifications`]: Access to retrieve the character's notifications
+//! - [`CharacterScopes::read_corporation_roles`]: Access to read the character's corporation roles
+//! - [`CharacterScopes::read_standings`]: Access to read the character's standings
+//! - [`CharacterScopes::read_titles`]: Access to read the character's corporation titles
 
 /// Access to retrieve information on character's research agents
 pub const READ_AGENTS_RESEARCH: &str = "esi-characters.read_agents_research.v1";
@@ -44,7 +54,7 @@ impl CharacterScopes {
         CharacterScopes { scopes: Vec::new() }
     }
 
-    /// Create a new instance of [`CharacterScopes`] with all scopes applied
+    /// Creates a new instance of [`CharacterScopes`] with all scopes applied
     pub fn all() -> Self {
         CharacterScopes::new()
             .read_agents_research()
@@ -58,73 +68,73 @@ impl CharacterScopes {
             .read_titles()
     }
 
-    /// Adds the `esi-characters.read_agents_research.v1` scope
-    ///
     /// Access to retrieve information on character's research agents
+    ///
+    /// Adds the `esi-characters.read_agents_research.v1` scope
     pub fn read_agents_research(mut self) -> Self {
         self.scopes.push(READ_AGENTS_RESEARCH.to_string());
         self
     }
 
-    /// Adds the `esi-characters.read_blueprints.v1` scope
-    ///
     /// Access to retrieve information on character's blueprints
+    ///
+    /// Adds the `esi-characters.read_blueprints.v1` scope
     pub fn read_blueprints(mut self) -> Self {
         self.scopes.push(READ_BLUEPRINTS.to_string());
         self
     }
 
-    /// Adds the `esi-characters.read_contacts.v1` scope
-    ///
     /// Access to read a character's contacts
+    ///
+    /// Adds the `esi-characters.read_contacts.v1` scope
     pub fn read_contacts(mut self) -> Self {
         self.scopes.push(READ_CONTACTS.to_string());
         self
     }
 
-    /// Adds the `esi-characters.read_fatigue.v1` scope
-    ///
     /// Access to retrieve information on character's jump fatigue status
+    ///
+    /// Adds the `esi-characters.read_fatigue.v1` scope
     pub fn read_fatigue(mut self) -> Self {
         self.scopes.push(READ_FATIGUE.to_string());
         self
     }
 
-    /// Adds the `esi-characters.read_medals.v1` scope
-    ///
     /// Access to retrieve information on character's medals
+    ///
+    /// Adds the `esi-characters.read_medals.v1` scope
     pub fn read_medals(mut self) -> Self {
         self.scopes.push(READ_MEDALS.to_string());
         self
     }
 
-    /// Adds the `esi-characters.read_notifications.v1` scope
-    ///
     /// Access to retrieve the character's notifications
+    ///
+    /// Adds the `esi-characters.read_notifications.v1` scope
     pub fn read_notifications(mut self) -> Self {
         self.scopes.push(READ_NOTIFICATIONS.to_string());
         self
     }
 
-    /// Adds the `esi-characters.read_corporation_roles.v1` scope
-    ///
     /// Access to read the character's corporation roles
+    ///
+    /// Adds the `esi-characters.read_corporation_roles.v1` scope
     pub fn read_corporation_roles(mut self) -> Self {
         self.scopes.push(READ_CORPORATION_ROLES.to_string());
         self
     }
 
-    /// Adds the `esi-characters.read_standings.v1` scope
-    ///
     /// Access to read the character's standings
+    ///
+    /// Adds the `esi-characters.read_standings.v1` scope
     pub fn read_standings(mut self) -> Self {
         self.scopes.push(READ_STANDINGS.to_string());
         self
     }
 
-    /// Adds the `esi-characters.read_titles.v1` scope
-    ///
     /// Access to read the character's corporation titles
+    ///
+    /// Adds the `esi-characters.read_titles.v1` scope
     pub fn read_titles(mut self) -> Self {
         self.scopes.push(READ_TITLES.to_string());
         self
@@ -133,7 +143,7 @@ impl CharacterScopes {
 
 #[cfg(test)]
 mod character_scopes_tests {
-    use crate::oauth2::scope::CharacterScopes;
+    use crate::scope::CharacterScopes;
 
     /// Tests initializing a default instance of [`CharacterScopes`]
     #[test]

--- a/src/scope/corporation.rs
+++ b/src/scope/corporation.rs
@@ -1,11 +1,23 @@
-//! # EVE Online OAuth2 Corporation Scopes
+//! # EVE ESI Corporation Scopes
 //!
 //! This module provides a type-safe way to add corporation-related scopes for OAuth2 to the [`super::ScopeBuilder`]
 //!
 //! See [module-level documentation](super) for an overview & usage of scopes for the esi_crate
 //!
-//! # Methods
+//! ## Methods
 //! - [`CorporationScopes::new`]: Creates a new instance of [`CorporationScopes`]
+//! - [`CorporationScopes::all`]: Creates a new instance of [`CorporationScopes`] with all scopes applied
+//! - [`CorporationScopes::read_blueprints`]: Access to retrieve information on corporation's blueprints
+//! - [`CorporationScopes::read_container_logs`]: Access to read information on corporation container logs
+//! - [`CorporationScopes::read_divisions`]: Access to retrieve information on corporation's wallet & hangar divisions
+//! - [`CorporationScopes::read_facilities`]: Access to retrieve information on corporation's industry facilities
+//! - [`CorporationScopes::read_medals`]: Access to retrieve information on corporation's medals
+//! - [`CorporationScopes::track_members`]: Access to member tracking-related information for a corporation
+//! - [`CorporationScopes::read_titles`]: Access to retrieve information on a corporation's member titles
+//! - [`CorporationScopes::read_corporation_membership`]: Access to read roles & membership for a corporation
+//! - [`CorporationScopes::read_standings`]: Access to retrieve information on a corporation's NPC standings
+//! - [`CorporationScopes::read_starbases`]: Access to retrieve information on a corporation's starbases (POSes)
+//! - [`CorporationScopes::read_structures`]: Access to retrieve information on corporation's Upwell structures
 
 /// Access to retrieve information on corporation's blueprints
 pub const READ_BLUEPRINTS: &str = "esi-corporations.read_blueprints.v1";
@@ -27,7 +39,7 @@ pub const READ_CORPORATION_MEMBERSHIP: &str = "esi-corporations.read_corporation
 pub const READ_STANDINGS: &str = "esi-corporations.read_standings.v1";
 /// Access to retrieve information on a corporation's starbases (POSes)
 pub const READ_STARBASES: &str = "esi-corporations.read_starbases.v1";
-/// Access to retrieve information on corporation's structures
+/// Access to retrieve information on corporation's Upwell structures
 pub const READ_STRUCTURES: &str = "esi-corporations.read_structures.v1";
 
 /// Struct with methods for listing corporation scopes to request for OAuth2
@@ -48,7 +60,7 @@ impl CorporationScopes {
         CorporationScopes { scopes: Vec::new() }
     }
 
-    /// Create a new instance of [`CorporationScopes`] with all scopes applied
+    /// Creates a new instance of [`CorporationScopes`] with all scopes applied
     pub fn all() -> Self {
         CorporationScopes::new()
             .read_blueprints()
@@ -64,89 +76,88 @@ impl CorporationScopes {
             .read_structures()
     }
 
-    /// Adds the `esi-corporations.read_blueprints.v1` scope
-    ///
     /// Access to retrieve information on corporation's blueprints
+    ///
+    /// Adds the `esi-corporations.read_blueprints.v1` scope
     pub fn read_blueprints(mut self) -> Self {
         self.scopes.push(READ_BLUEPRINTS.to_string());
         self
     }
 
-    /// Adds the `esi-corporations.read_container_logs.v1` scope
-    ///
     /// Access to read information on corporation container logs
+    ///
+    /// Adds the `esi-corporations.read_container_logs.v1` scope
     pub fn read_container_logs(mut self) -> Self {
         self.scopes.push(READ_CONTAINER_LOGS.to_string());
         self
     }
 
-    /// Adds the `esi-corporations.read_divisions.v1` scope
-    ///
     /// Access to retrieve information on corporation's wallet & hangar divisions
+    ///
+    /// Adds the `esi-corporations.read_divisions.v1` scope
     pub fn read_divisions(mut self) -> Self {
         self.scopes.push(READ_DIVISIONS.to_string());
         self
     }
 
-    /// Adds the `esi-corporations.read_facilities.v1` scope
-    ///
     /// Access to retrieve information on corporation's industry facilities
+    ///
+    /// Adds the `esi-corporations.read_facilities.v1` scope
     pub fn read_facilities(mut self) -> Self {
         self.scopes.push(READ_FACILITIES.to_string());
         self
     }
 
-    /// Adds the `esi-corporations.read_medals.v1` scope
-    ///
     /// Access to retrieve information on corporation's medals
+    ///
+    /// Adds the `esi-corporations.read_medals.v1` scope
     pub fn read_medals(mut self) -> Self {
         self.scopes.push(READ_MEDALS.to_string());
         self
     }
 
-    /// Adds the `esi-corporations.track_members.v1` scope
-    ///
     /// Access to member tracking-related information for a corporation
+    ///
+    /// Adds the `esi-corporations.track_members.v1` scope
     pub fn track_members(mut self) -> Self {
         self.scopes.push(TRACK_MEMBERS.to_string());
         self
     }
 
-    /// Adds the `esi-corporations.read_titles.v1` scope
-    ///
     /// Access to retrieve information on a corporation's member titles
+    ///
+    /// Adds the `esi-corporations.read_titles.v1` scope
     pub fn read_titles(mut self) -> Self {
         self.scopes.push(READ_TITLES.to_string());
         self
     }
 
-    /// Adds the `esi-corporations.read_corporation_membership.v1` scope
-    ///
     /// Access to read roles & membership for a corporation
+    ///
+    /// Adds the `esi-corporations.read_corporation_membership.v1` scope
     pub fn read_corporation_membership(mut self) -> Self {
         self.scopes.push(READ_CORPORATION_MEMBERSHIP.to_string());
         self
     }
-
-    /// Adds the `esi-corporations.read_standings.v1` scope
-    ///
     /// Access to retrieve information on a corporation's NPC standings
+    ///
+    /// Adds the `esi-corporations.read_standings.v1` scope
     pub fn read_standings(mut self) -> Self {
         self.scopes.push(READ_STANDINGS.to_string());
         self
     }
 
-    /// Adds the `esi-corporations.read_starbases.v1` scope
-    ///
     /// Access to retrieve information on a corporation's starbases (POSes)
+    ///
+    /// Adds the `esi-corporations.read_starbases.v1` scope
     pub fn read_starbases(mut self) -> Self {
         self.scopes.push(READ_STARBASES.to_string());
         self
     }
 
-    /// Adds the `esi-corporations.read_structures.v1` scope
+    /// Access to retrieve information on corporation's Upwell structures
     ///
-    /// Access to retrieve information on corporation's structures
+    /// Adds the `esi-corporations.read_structures.v1` scope
     pub fn read_structures(mut self) -> Self {
         self.scopes.push(READ_STRUCTURES.to_string());
         self
@@ -155,7 +166,7 @@ impl CorporationScopes {
 
 #[cfg(test)]
 mod corporation_scopes_tests {
-    use crate::oauth2::scope::CorporationScopes;
+    use crate::scope::CorporationScopes;
 
     /// Tests initializing a default instance of [`CorporationScopes`]
     #[test]

--- a/src/scope/market.rs
+++ b/src/scope/market.rs
@@ -1,0 +1,82 @@
+//! # EVE ESI Market Scopes
+//!
+//! This module provides a type-safe way to add market-related scopes for OAuth2 to the [`super::ScopeBuilder`]
+//!
+//! See [module-level documentation](super) for an overview & usage of scopes for the esi_crate
+//!
+//! ## Methods
+//! - [`MarketScopes::new`]: Creates a new instance of [`MarketScopes`]
+//! - [`MarketScopes::all`]: Creates a new instance of [`MarketScopes`] with all scopes applied
+//! - [`MarketScopes::read_character_orders`]: Access to retrieve information on character's market orders
+//! - [`MarketScopes::read_corporation_orders`]: Access to retrieve information on corporation's market orders
+//! - [`MarketScopes::structure_markets`]: Access to retrieve information on a structure's market orders
+
+/// Access to retrieve information on character's market orders
+pub const READ_CHARACTER_ORDERS: &str = "esi-markets.read_character_orders.v1";
+/// Access to retrieve information on corporation's market orders
+pub const READ_CORPORATION_ORDERS: &str = "esi-markets.read_corporation_orders.v1";
+/// Access to retrieve information on a structure's market orders
+pub const STRUCTURE_MARKETS: &str = "esi-markets.structure_markets.v1";
+
+/// Struct with methods for listing corporation scopes to request for OAuth2
+pub struct MarketScopes {
+    pub(super) scopes: Vec<String>,
+}
+
+impl Default for MarketScopes {
+    /// Create a default instance of [`MarketScopes`]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MarketScopes {
+    /// Create a new instance of [`MarketScopes`]
+    pub fn new() -> Self {
+        MarketScopes { scopes: Vec::new() }
+    }
+
+    /// Creates a new instance of [`MarketScopes`] with all scopes applied
+    pub fn all() -> Self {
+        MarketScopes::new()
+            .read_character_orders()
+            .read_corporation_orders()
+    }
+
+    /// Access to retrieve information on character's market orders
+    ///
+    /// Adds the `esi-markets.read_character_orders.v1` scope
+    pub fn read_character_orders(mut self) -> Self {
+        self.scopes.push(READ_CHARACTER_ORDERS.to_string());
+        self
+    }
+
+    /// Access to retrieve information on corporation's market orders
+    ///
+    /// Adds the `esi-markets.read_corporation_orders.v1` scope
+    pub fn read_corporation_orders(mut self) -> Self {
+        self.scopes.push(READ_CORPORATION_ORDERS.to_string());
+        self
+    }
+
+    /// Access to retrieve information on a structure's market orders
+    ///
+    /// Adds the `esi-markets.structure_markets.v1` scope
+    pub fn structure_markets(mut self) -> Self {
+        self.scopes.push(STRUCTURE_MARKETS.to_string());
+        self
+    }
+}
+
+#[cfg(test)]
+mod market_scopes_tests {
+    use crate::scope::MarketScopes;
+
+    /// Tests initializing a default instance of [`MarketScopes`]
+    #[test]
+    fn test_market_scopes_default() {
+        let market_scopes = MarketScopes::default();
+
+        assert_eq!(market_scopes.scopes.len(), 0)
+    }
+}

--- a/src/scope/mod.rs
+++ b/src/scope/mod.rs
@@ -1,4 +1,4 @@
-//! # EVE Online OAuth2 Scopes
+//! # EVE ESI Scopes
 //!
 //! This module provides the [`ScopeBuilder`] & related modules with methods to build a list of scopes to request during
 //! login in a type-safe manner.
@@ -16,7 +16,7 @@
 //!
 //! ```rust
 //! use eve_esi::ScopeBuilder;
-//! use eve_esi::oauth2::scope::CharacterScopes;
+//! use eve_esi::scope::CharacterScopes;
 //!
 //! // Create a new scope builder
 //! let scopes = ScopeBuilder::new()
@@ -33,17 +33,19 @@
 //! // Use with `esi_client.oauth2().login_url(scopes)` method...
 //! ```
 //!
-//! See the [`super::login`] module for an example of usage of the [`ScopeBuilder`] with the
+//! See the [`crate::oauth2::login`] module documentation for an example of usage of the [`ScopeBuilder`] with the
 //! [`login_url`](crate::oauth2::OAuth2Api::login_url) method.
 
 pub mod builder;
 
 pub mod character;
 pub mod corporation;
+pub mod market;
 pub mod wallet;
 
 pub use builder::ScopeBuilder;
 
 pub use character::CharacterScopes;
 pub use corporation::CorporationScopes;
+pub use market::MarketScopes;
 pub use wallet::WalletScopes;

--- a/src/scope/wallet.rs
+++ b/src/scope/wallet.rs
@@ -1,4 +1,4 @@
-//! # EVE Online OAuth2 Wallet Scopes
+//! # EVE ESI Wallet Scopes
 //!
 //! This module provides a type-safe way to add wallet-related scopes for OAuth2 to the [`super::ScopeBuilder`]
 //!
@@ -6,6 +6,8 @@
 //!
 //! # Methods
 //! - [`WalletScopes::new`]: Creates a new instance of [`WalletScopes`]
+//! - [`WalletScopes::new`]: Creates a new instance of [`WalletScopes`] with all scopes applied
+//! - [`WalletScopes::read_corporation_wallets`]: Access to retrieve information for character's corporation wallets
 
 /// Access to retrieve information for character's corporation wallets
 pub const READ_CORPORATION_WALLETS: &str = "esi-wallet.read_corporation_wallets.v1";
@@ -28,14 +30,14 @@ impl WalletScopes {
         WalletScopes { scopes: Vec::new() }
     }
 
-    /// Create a new instance of [`WalletScopes`] with all scopes applied
+    /// Creates a new instance of [`WalletScopes`] with all scopes applied
     pub fn all() -> Self {
         WalletScopes::new().read_corporation_wallets()
     }
 
-    /// Adds the `esi-wallet.read_corporation_wallets.v1` scope
-    ///
     /// Access to retrieve information for character's corporation wallets
+    ///
+    /// Adds the `esi-wallet.read_corporation_wallets.v1` scope
     pub fn read_corporation_wallets(mut self) -> Self {
         self.scopes.push(READ_CORPORATION_WALLETS.to_string());
         self
@@ -44,7 +46,7 @@ impl WalletScopes {
 
 #[cfg(test)]
 mod wallet_scopes_tests {
-    use crate::oauth2::scope::WalletScopes;
+    use crate::scope::WalletScopes;
 
     /// Tests initializing a default instance of [`WalletScopes`]
     #[test]

--- a/tests/endpoints/character.rs
+++ b/tests/endpoints/character.rs
@@ -1,4 +1,4 @@
-use eve_esi::{oauth2::scope::CharacterScopes, ScopeBuilder};
+use eve_esi::{scope::CharacterScopes, ScopeBuilder};
 
 use crate::endpoints::util::{authenticated_endpoint_test_setup, mock_access_token_with_scopes};
 use crate::util::integration_test_setup;

--- a/tests/endpoints/corporation.rs
+++ b/tests/endpoints/corporation.rs
@@ -1,4 +1,4 @@
-use eve_esi::oauth2::scope::{CorporationScopes, WalletScopes};
+use eve_esi::scope::{CorporationScopes, WalletScopes};
 use eve_esi::ScopeBuilder;
 
 use crate::endpoints::util::{authenticated_endpoint_test_setup, mock_access_token_with_scopes};

--- a/tests/endpoints/market.rs
+++ b/tests/endpoints/market.rs
@@ -1,0 +1,305 @@
+use eve_esi::model::enums::market::OrderType;
+use eve_esi::{scope::MarketScopes, ScopeBuilder};
+
+use crate::endpoints::util::{authenticated_endpoint_test_setup, mock_access_token_with_scopes};
+use crate::util::integration_test_setup;
+
+authenticated_endpoint_test! {
+    list_open_orders_from_a_character,
+    |esi_client: eve_esi::Client, access_token: String | async move {
+        let character_id = 2114794365;
+        esi_client
+            .market()
+            .list_open_orders_from_a_character(&access_token, character_id)
+            .await
+    },
+    request_type = "GET",
+    url = "/characters/2114794365/orders",
+    required_scopes = ScopeBuilder::new()
+        .market(MarketScopes::new().read_character_orders())
+        .build();
+    mock_response = serde_json::json!([
+      {
+        "duration": 0,
+        "escrow": 0,
+        "is_buy_order": true,
+        "is_corporation": true,
+        "issued": "2019-08-24T14:15:22Z",
+        "location_id": 0,
+        "min_volume": 0,
+        "order_id": 0,
+        "price": 0,
+        "range": "1",
+        "region_id": 0,
+        "type_id": 0,
+        "volume_remain": 0,
+        "volume_total": 0
+      }
+    ]),
+}
+
+authenticated_endpoint_test! {
+    list_historical_orders_by_a_character,
+    |esi_client: eve_esi::Client, access_token: String | async move {
+        let character_id = 2114794365;
+        let page = 1;
+        esi_client
+            .market()
+            .list_historical_orders_by_a_character(&access_token, character_id, page)
+            .await
+    },
+    request_type = "GET",
+    url = "/characters/2114794365/orders/history?page=1",
+    required_scopes = ScopeBuilder::new()
+        .market(MarketScopes::new().read_character_orders())
+        .build();
+    mock_response = serde_json::json!([
+      {
+        "duration": 0,
+        "escrow": 0,
+        "is_buy_order": true,
+        "is_corporation": true,
+        "issued": "2019-08-24T14:15:22Z",
+        "location_id": 0,
+        "min_volume": 0,
+        "order_id": 0,
+        "price": 0,
+        "range": "1",
+        "region_id": 0,
+        "state": "cancelled",
+        "type_id": 0,
+        "volume_remain": 0,
+        "volume_total": 0
+      }
+    ]),
+}
+
+authenticated_endpoint_test! {
+    list_open_orders_from_a_corporation,
+    |esi_client: eve_esi::Client, access_token: String | async move {
+        let corporation_id = 98785281;
+        esi_client
+            .market()
+            .list_open_orders_from_a_corporation(&access_token, corporation_id)
+            .await
+    },
+    request_type = "GET",
+    url = "/corporations/98785281/orders",
+    required_scopes = ScopeBuilder::new()
+        .market(MarketScopes::new().read_corporation_orders())
+        .build();
+    mock_response = serde_json::json!([
+      {
+        "duration": 0,
+        "escrow": 0,
+        "is_buy_order": true,
+        "issued": "2019-08-24T14:15:22Z",
+        "issued_by": 0,
+        "location_id": 0,
+        "min_volume": 0,
+        "order_id": 0,
+        "price": 0,
+        "range": "1",
+        "region_id": 0,
+        "type_id": 0,
+        "volume_remain": 0,
+        "volume_total": 0,
+        "wallet_division": 0
+      }
+    ]),
+}
+
+authenticated_endpoint_test! {
+    list_historical_orders_from_a_corporation,
+    |esi_client: eve_esi::Client, access_token: String | async move {
+        let corporation_id = 98785281;
+        let page = 1;
+        esi_client
+            .market()
+            .list_historical_orders_from_a_corporation(&access_token, corporation_id, page)
+            .await
+    },
+    request_type = "GET",
+    url = "/corporations/98785281/orders/history?page=1",
+    required_scopes = ScopeBuilder::new()
+        .market(MarketScopes::new().read_corporation_orders())
+        .build();
+    mock_response = serde_json::json!([
+      {
+        "duration": 0,
+        "escrow": 0,
+        "is_buy_order": true,
+        "issued": "2019-08-24T14:15:22Z",
+        "issued_by": 0,
+        "location_id": 0,
+        "min_volume": 0,
+        "order_id": 0,
+        "price": 0,
+        "range": "1",
+        "region_id": 0,
+        "state": "cancelled",
+        "type_id": 0,
+        "volume_remain": 0,
+        "volume_total": 0,
+        "wallet_division": 0
+      }
+    ]),
+}
+
+public_endpoint_test! {
+    get_item_groups,
+    |esi_client: eve_esi::Client | async move {
+        esi_client
+            .market()
+            .get_item_groups()
+            .await
+    },
+    request_type = "GET",
+    url = "/markets/groups",
+    mock_response = serde_json::json!([
+      0
+    ])
+}
+
+public_endpoint_test! {
+    get_item_group_information,
+    |esi_client: eve_esi::Client | async move {
+        let market_group_id = 1;
+        esi_client
+            .market()
+            .get_item_group_information(market_group_id)
+            .await
+    },
+    request_type = "GET",
+    url = "/markets/groups/1",
+    mock_response = serde_json::json!({
+      "description": "string",
+      "market_group_id": 0,
+      "name": "string",
+      "parent_group_id": 0,
+      "types": [
+        0
+      ]
+    })
+}
+
+public_endpoint_test! {
+    list_market_prices,
+    |esi_client: eve_esi::Client | async move {
+        esi_client
+            .market()
+            .list_market_prices()
+            .await
+    },
+    request_type = "GET",
+    url = "/markets/prices",
+    mock_response = serde_json::json!([
+      {
+        "adjusted_price": 0,
+        "average_price": 0,
+        "type_id": 0
+      }
+    ])
+}
+
+authenticated_endpoint_test! {
+    list_orders_in_a_structure,
+    |esi_client: eve_esi::Client, access_token: String | async move {
+        let structure_id = 1;
+        let page = 1;
+        esi_client
+            .market()
+            .list_orders_in_a_structure(&access_token, structure_id, page)
+            .await
+    },
+    request_type = "GET",
+    url = "/markets/structures/1?page=1",
+    required_scopes = ScopeBuilder::new()
+        .market(MarketScopes::new().structure_markets())
+        .build();
+    mock_response = serde_json::json!([
+      {
+        "duration": 0,
+        "is_buy_order": true,
+        "issued": "2019-08-24T14:15:22Z",
+        "location_id": 0,
+        "min_volume": 0,
+        "order_id": 0,
+        "price": 0,
+        "range": "station",
+        "type_id": 0,
+        "volume_remain": 0,
+        "volume_total": 0
+      }
+    ]),
+}
+
+public_endpoint_test! {
+    list_historical_market_statistics_in_a_region,
+    |esi_client: eve_esi::Client | async move {
+        let region_id = 1;
+        let type_id = 1;
+        esi_client
+            .market()
+            .list_historical_market_statistics_in_a_region(region_id, type_id)
+            .await
+    },
+    request_type = "GET",
+    url = "/markets/1/history?type_id=1",
+    mock_response = serde_json::json!([
+      {
+        "average": 0,
+        "date": "2019-08-24",
+        "highest": 0,
+        "lowest": 0,
+        "order_count": 0,
+        "volume": 0
+      }
+    ])
+}
+
+public_endpoint_test! {
+    list_orders_in_a_region,
+    |esi_client: eve_esi::Client | async move {
+        let region_id = 1;
+        let order_type = OrderType::All;
+        let page = 1;
+        esi_client
+            .market()
+            .list_orders_in_a_region(region_id, order_type, page)
+            .await
+    },
+    request_type = "GET",
+    url = "/markets/1/orders?order_type=all&page=1",
+    mock_response = serde_json::json!([
+      {
+        "duration": 0,
+        "is_buy_order": true,
+        "issued": "2019-08-24T14:15:22Z",
+        "location_id": 0,
+        "min_volume": 0,
+        "order_id": 0,
+        "price": 0,
+        "range": "station",
+        "system_id": 0,
+        "type_id": 0,
+        "volume_remain": 0,
+        "volume_total": 0
+      }
+    ])
+}
+
+public_endpoint_test! {
+    list_type_ids_relevant_to_a_market,
+    |esi_client: eve_esi::Client | async move {
+        let region_id = 1;
+        let page = 1;
+        esi_client
+            .market()
+            .list_type_ids_relevant_to_a_market(region_id, page)
+            .await
+    },
+    request_type = "GET",
+    url = "/markets/1/types?page=1",
+    mock_response = serde_json::json!([0])
+}

--- a/tests/endpoints/mod.rs
+++ b/tests/endpoints/mod.rs
@@ -4,4 +4,5 @@ mod macros;
 mod alliance;
 mod character;
 mod corporation;
+mod market;
 mod util;


### PR DESCRIPTION
# Breaking

The `scopes` module has been moved from `src/oauth2` to instead be directly under `src/`. 

Scope imports will need to be changed from:

```rust
use eve_esi::oauth2::scope::CharacterScopes;
```

to

```rust
use eve_esi::scope::CharacterScopes;
```

# New Endpoints

11 new market endpoints have been added which includes 6 public & 5 authenticated endpoints

## Public (6)
- `get_item_groups`: Retrieves a list of IDs of market item groups
- `get_item_group_information`: Retrieves the information of the provided market item group ID
- `list_market_prices`: Retrieves the average & adjusted market prices of all items
- `list_historical_market_statistics_in_a_region`: List of entries with historical market statistics for the provided item type ID in provided region ID
- `list_orders_in_a_region`: Retrieves a list of market orders within the provided region ID and of the specified order type
- `list_type_ids_relevant_to_a_market`: Retrieves a list of type IDs that have active market orders for the given region ID

## Authenticated (5)
- `list_open_orders_from_a_character`: Fetches list of open market orders for the provided character ID
- `list_historical_orders_by_a_character`: Fetches list of cancelled & expired market orders for the provided character ID up to 90 days in the past
- `list_open_orders_from_a_corporation`: Fetches list of open market orders for the provided corporation ID
- `list_historical_orders_from_a_corporation`: Fetches list of cancelled & expired market orders for the provided corporation ID up to 90 days in the past
- `list_orders_in_a_structure`: Fetches list of market orders for the provided structure ID

# Docs Updates

- Updated oauth2 module docs to link to OAuth2-related usage examples
- Updated module documentation for character, corporation, and alliance models, enums, scopes, and endpoints to include links to methods, models, enums, and scope methods within the module.