### PR TITLE
Url serialization in endpoint macros

### DIFF
--- a/src/endpoints/assets.rs
+++ b/src/endpoints/assets.rs
@@ -102,7 +102,7 @@ impl<'a> AssetsEndpoints<'a> {
         auth_post get_character_asset_locations(
             access_token: &str,
             item_ids: Vec<i64>,
-            character_id: i64,
+            character_id: i64;
         ) -> Result<Vec<AssetLocation>, Error>
         url = "{}/characters/{}/assets/locations";
         label = "asset locations";
@@ -140,7 +140,7 @@ impl<'a> AssetsEndpoints<'a> {
         auth_post get_character_asset_names(
             access_token: &str,
             item_ids: Vec<i64>,
-            character_id: i64,
+            character_id: i64;
         ) -> Result<Vec<AssetName>, Error>
         url = "{}/characters/{}/assets/names";
         label = "asset names";
@@ -208,7 +208,7 @@ impl<'a> AssetsEndpoints<'a> {
         auth_post get_corporation_asset_locations(
             access_token: &str,
             item_ids: Vec<i64>,
-            corporation_id: i64,
+            corporation_id: i64;
         ) -> Result<Vec<AssetLocation>, Error>
         url = "{}/corporations/{}/assets/locations";
         label = "asset locations";
@@ -246,7 +246,7 @@ impl<'a> AssetsEndpoints<'a> {
         auth_post get_corporation_asset_names(
             access_token: &str,
             item_ids: Vec<i64>,
-            corporation_id: i64,
+            corporation_id: i64;
         ) -> Result<Vec<AssetName>, Error>
         url = "{}/corporations/{}/assets/names";
         label = "asset names";

--- a/src/endpoints/assets.rs
+++ b/src/endpoints/assets.rs
@@ -102,7 +102,7 @@ impl<'a> AssetsEndpoints<'a> {
         auth_post get_character_asset_locations(
             access_token: &str,
             item_ids: Vec<i64>,
-            character_id: i64;
+            character_id: i64
         ) -> Result<Vec<AssetLocation>, Error>
         url = "{}/characters/{}/assets/locations";
         label = "asset locations";
@@ -140,7 +140,7 @@ impl<'a> AssetsEndpoints<'a> {
         auth_post get_character_asset_names(
             access_token: &str,
             item_ids: Vec<i64>,
-            character_id: i64;
+            character_id: i64
         ) -> Result<Vec<AssetName>, Error>
         url = "{}/characters/{}/assets/names";
         label = "asset names";
@@ -208,7 +208,7 @@ impl<'a> AssetsEndpoints<'a> {
         auth_post get_corporation_asset_locations(
             access_token: &str,
             item_ids: Vec<i64>,
-            corporation_id: i64;
+            corporation_id: i64
         ) -> Result<Vec<AssetLocation>, Error>
         url = "{}/corporations/{}/assets/locations";
         label = "asset locations";
@@ -246,7 +246,7 @@ impl<'a> AssetsEndpoints<'a> {
         auth_post get_corporation_asset_names(
             access_token: &str,
             item_ids: Vec<i64>,
-            corporation_id: i64;
+            corporation_id: i64
         ) -> Result<Vec<AssetName>, Error>
         url = "{}/corporations/{}/assets/names";
         label = "asset names";

--- a/src/endpoints/assets.rs
+++ b/src/endpoints/assets.rs
@@ -66,10 +66,10 @@ impl<'a> AssetsEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_character_assets(
             access_token: &str,
-            character_id: i64,
+            character_id: i64;
             page: i32
         ) -> Result<Vec<Asset>, Error>
-        url = "{}/characters/{}/assets?page={}";
+        url = "{}/characters/{}/assets";
         label = "assets";
         required_scopes = ScopeBuilder::new()
             .assets(AssetsScopes::new().read_assets())
@@ -172,10 +172,10 @@ impl<'a> AssetsEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_corporation_assets(
             access_token: &str,
-            corporation_id: i64,
+            corporation_id: i64;
             page: i32
         ) -> Result<Vec<Asset>, Error>
-        url = "{}/corporations/{}/assets?page={}";
+        url = "{}/corporations/{}/assets";
         label = "assets";
         required_scopes = ScopeBuilder::new()
             .assets(AssetsScopes::new().read_corporation_assets())

--- a/src/endpoints/calendar.rs
+++ b/src/endpoints/calendar.rs
@@ -73,7 +73,7 @@ impl<'a> CalendarEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get list_calendar_event_summaries(
             access_token: &str,
-            character_id: i64,
+            character_id: i64;
         ) -> Result<Vec<CalendarEventSummary>, Error>
         url = "{}/characters/{}/calendar";
         label = "calendar events";
@@ -106,7 +106,7 @@ impl<'a> CalendarEndpoints<'a> {
         auth_get get_an_event(
             access_token: &str,
             character_id: i64,
-            event_id: i64
+            event_id: i64;
         ) -> Result<CalendarEvent, Error>
         url = "{}/characters/{}/calendar/{}";
         label = "calendar events";
@@ -174,7 +174,7 @@ impl<'a> CalendarEndpoints<'a> {
         auth_get get_attendees(
             access_token: &str,
             character_id: i64,
-            event_id: i64
+            event_id: i64;
         ) -> Result<Vec<CalendarEventAttendee>, Error>
         url = "{}/characters/{}/calendar/{}/attendees";
         label = "calendar event attendees";

--- a/src/endpoints/calendar.rs
+++ b/src/endpoints/calendar.rs
@@ -73,7 +73,7 @@ impl<'a> CalendarEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get list_calendar_event_summaries(
             access_token: &str,
-            character_id: i64;
+            character_id: i64
         ) -> Result<Vec<CalendarEventSummary>, Error>
         url = "{}/characters/{}/calendar";
         label = "calendar events";
@@ -106,7 +106,7 @@ impl<'a> CalendarEndpoints<'a> {
         auth_get get_an_event(
             access_token: &str,
             character_id: i64,
-            event_id: i64;
+            event_id: i64
         ) -> Result<CalendarEvent, Error>
         url = "{}/characters/{}/calendar/{}";
         label = "calendar events";
@@ -141,7 +141,7 @@ impl<'a> CalendarEndpoints<'a> {
             access_token: &str,
             event_response: PutCalendarEventResponse,
             character_id: i64,
-            event_id: i64;
+            event_id: i64
         ) -> Result<(), Error>
         url = "{}/characters/{}/calendar/{}";
         label = "respond to calendar event";
@@ -174,7 +174,7 @@ impl<'a> CalendarEndpoints<'a> {
         auth_get get_attendees(
             access_token: &str,
             character_id: i64,
-            event_id: i64;
+            event_id: i64
         ) -> Result<Vec<CalendarEventAttendee>, Error>
         url = "{}/characters/{}/calendar/{}/attendees";
         label = "calendar event attendees";

--- a/src/endpoints/calendar.rs
+++ b/src/endpoints/calendar.rs
@@ -141,7 +141,7 @@ impl<'a> CalendarEndpoints<'a> {
             access_token: &str,
             event_response: PutCalendarEventResponse,
             character_id: i64,
-            event_id: i64
+            event_id: i64;
         ) -> Result<(), Error>
         url = "{}/characters/{}/calendar/{}";
         label = "respond to calendar event";

--- a/src/endpoints/character.rs
+++ b/src/endpoints/character.rs
@@ -126,7 +126,7 @@ impl<'a> CharacterEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_agents_research(
             access_token: &str,
-            character_id: i64;
+            character_id: i64
         ) -> Result<Vec<CharacterResearchAgent>, Error>
         url = "{}/characters/{}/agents_research";
         label = "research agents";
@@ -159,7 +159,7 @@ impl<'a> CharacterEndpoints<'a> {
         auth_get get_blueprints(
             access_token: &str,
             character_id: i64;
-            page: i32,
+            page: i32
         ) -> Result<Vec<Blueprint>, Error>
         url = "{}/characters/{}/blueprints";
         label = "blueprints";
@@ -212,7 +212,7 @@ impl<'a> CharacterEndpoints<'a> {
         auth_post calculate_a_cspa_charge_cost(
             access_token: &str,
             character_ids: Vec<i64>,
-            character_id: i64;
+            character_id: i64
         ) -> Result<f64, Error>
         url = "{}/characters/{}/cspa";
         label = "CSPA charge cost";
@@ -241,7 +241,7 @@ impl<'a> CharacterEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_jump_fatigue(
             access_token: &str,
-            character_id: i64;
+            character_id: i64
         ) -> Result<CharacterJumpFatigue, Error>
         url = "{}/characters/{}/fatigue";
         label = "jump fatigue";
@@ -270,7 +270,7 @@ impl<'a> CharacterEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_medals(
             access_token: &str,
-            character_id: i64;
+            character_id: i64
         ) -> Result<Vec<CharacterMedal>, Error>
         url = "{}/characters/{}/medals";
         label = "medals";
@@ -299,7 +299,7 @@ impl<'a> CharacterEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_character_notifications(
             access_token: &str,
-            character_id: i64;
+            character_id: i64
         ) -> Result<Vec<CharacterNotification>, Error>
         url = "{}/characters/{}/notifications";
         label = "notifications";
@@ -329,7 +329,7 @@ impl<'a> CharacterEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_new_contact_notifications(
             access_token: &str,
-            character_id: i64;
+            character_id: i64
         ) -> Result<Vec<CharacterNewContactNotification>, Error>
         url = "{}/characters/{}/notifications/contacts";
         label = "new contact notifications";
@@ -379,7 +379,7 @@ impl<'a> CharacterEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_character_corporation_roles(
             access_token: &str,
-            character_id: i64;
+            character_id: i64
         ) -> Result<CharacterCorporationRole, Error>
         url = "{}/characters/{}/roles";
         label = "corporation roles";
@@ -407,7 +407,7 @@ impl<'a> CharacterEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_standings(
             access_token: &str,
-            character_id: i64;
+            character_id: i64
         ) -> Result<Vec<Standing>, Error>
         url = "{}/characters/{}/standings";
         label = "NPC standings";
@@ -436,7 +436,7 @@ impl<'a> CharacterEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_character_corporation_titles(
             access_token: &str,
-            character_id: i64;
+            character_id: i64
         ) -> Result<Vec<CharacterCorporationTitle>, Error>
         url = "{}/characters/{}/titles";
         label = "standings";

--- a/src/endpoints/character.rs
+++ b/src/endpoints/character.rs
@@ -126,7 +126,7 @@ impl<'a> CharacterEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_agents_research(
             access_token: &str,
-            character_id: i64,
+            character_id: i64;
         ) -> Result<Vec<CharacterResearchAgent>, Error>
         url = "{}/characters/{}/agents_research";
         label = "research agents";
@@ -158,10 +158,10 @@ impl<'a> CharacterEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_blueprints(
             access_token: &str,
-            character_id: i64,
+            character_id: i64;
             page: i32,
         ) -> Result<Vec<Blueprint>, Error>
-        url = "{}/characters/{}/blueprints?page={}";
+        url = "{}/characters/{}/blueprints";
         label = "blueprints";
         required_scopes = ScopeBuilder::new().characters(CharactersScopes::new().read_blueprints()).build();
     }
@@ -241,7 +241,7 @@ impl<'a> CharacterEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_jump_fatigue(
             access_token: &str,
-            character_id: i64
+            character_id: i64;
         ) -> Result<CharacterJumpFatigue, Error>
         url = "{}/characters/{}/fatigue";
         label = "jump fatigue";
@@ -270,7 +270,7 @@ impl<'a> CharacterEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_medals(
             access_token: &str,
-            character_id: i64
+            character_id: i64;
         ) -> Result<Vec<CharacterMedal>, Error>
         url = "{}/characters/{}/medals";
         label = "medals";
@@ -299,7 +299,7 @@ impl<'a> CharacterEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_character_notifications(
             access_token: &str,
-            character_id: i64
+            character_id: i64;
         ) -> Result<Vec<CharacterNotification>, Error>
         url = "{}/characters/{}/notifications";
         label = "notifications";
@@ -329,7 +329,7 @@ impl<'a> CharacterEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_new_contact_notifications(
             access_token: &str,
-            character_id: i64
+            character_id: i64;
         ) -> Result<Vec<CharacterNewContactNotification>, Error>
         url = "{}/characters/{}/notifications/contacts";
         label = "new contact notifications";
@@ -379,7 +379,7 @@ impl<'a> CharacterEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_character_corporation_roles(
             access_token: &str,
-            character_id: i64
+            character_id: i64;
         ) -> Result<CharacterCorporationRole, Error>
         url = "{}/characters/{}/roles";
         label = "corporation roles";
@@ -407,7 +407,7 @@ impl<'a> CharacterEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_standings(
             access_token: &str,
-            character_id: i64
+            character_id: i64;
         ) -> Result<Vec<Standing>, Error>
         url = "{}/characters/{}/standings";
         label = "NPC standings";
@@ -436,7 +436,7 @@ impl<'a> CharacterEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_character_corporation_titles(
             access_token: &str,
-            character_id: i64
+            character_id: i64;
         ) -> Result<Vec<CharacterCorporationTitle>, Error>
         url = "{}/characters/{}/titles";
         label = "standings";

--- a/src/endpoints/character.rs
+++ b/src/endpoints/character.rs
@@ -212,7 +212,7 @@ impl<'a> CharacterEndpoints<'a> {
         auth_post calculate_a_cspa_charge_cost(
             access_token: &str,
             character_ids: Vec<i64>,
-            character_id: i64
+            character_id: i64;
         ) -> Result<f64, Error>
         url = "{}/characters/{}/cspa";
         label = "CSPA charge cost";

--- a/src/endpoints/clones.rs
+++ b/src/endpoints/clones.rs
@@ -57,7 +57,7 @@ impl<'a> ClonesEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_clones(
             access_token: &str,
-            character_id: i64;
+            character_id: i64
         ) -> Result<CharacterClones, Error>
         url = "{}/characters/{}/clones";
         label = "clones";
@@ -88,7 +88,7 @@ impl<'a> ClonesEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_active_implants(
             access_token: &str,
-            character_id: i64;
+            character_id: i64
         ) -> Result<Vec<i64>, Error>
         url = "{}/characters/{}/implants";
         label = "implants for active clone";

--- a/src/endpoints/clones.rs
+++ b/src/endpoints/clones.rs
@@ -57,7 +57,7 @@ impl<'a> ClonesEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_clones(
             access_token: &str,
-            character_id: i64
+            character_id: i64;
         ) -> Result<CharacterClones, Error>
         url = "{}/characters/{}/clones";
         label = "clones";
@@ -88,7 +88,7 @@ impl<'a> ClonesEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_active_implants(
             access_token: &str,
-            character_id: i64
+            character_id: i64;
         ) -> Result<Vec<i64>, Error>
         url = "{}/characters/{}/implants";
         label = "implants for active clone";

--- a/src/endpoints/contacts.rs
+++ b/src/endpoints/contacts.rs
@@ -71,7 +71,7 @@ impl<'a> ContactsEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_alliance_contacts(
             access_token: &str,
-            alliance_id: i64;
+            alliance_id: i64
         ) -> Result<Vec<AllianceContact>, Error>
         url = "{}/alliances/{}/contacts";
         label = "contacts";
@@ -102,7 +102,7 @@ impl<'a> ContactsEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_alliance_contact_labels(
             access_token: &str,
-            alliance_id: i64;
+            alliance_id: i64
         ) -> Result<Vec<ContactLabel>, Error>
         url = "{}/alliances/{}/contacts/labels";
         label = "contact labels";
@@ -166,7 +166,7 @@ impl<'a> ContactsEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_contacts(
             access_token: &str,
-            character_id: i64;
+            character_id: i64
         ) -> Result<Vec<CharacterContact>, Error>
         url = "{}/characters/{}/contacts";
         label = "contacts";
@@ -337,7 +337,7 @@ impl<'a> ContactsEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_contact_labels(
             access_token: &str,
-            character_id: i64;
+            character_id: i64
         ) -> Result<Vec<ContactLabel>, Error>
         url = "{}/characters/{}/contacts/labels";
         label = "contact labels";
@@ -368,7 +368,7 @@ impl<'a> ContactsEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_corporation_contacts(
             access_token: &str,
-            corporation_id: i64;
+            corporation_id: i64
         ) -> Result<Vec<CorporationContact>, Error>
         url = "{}/corporations/{}/contacts";
         label = "contacts";
@@ -399,7 +399,7 @@ impl<'a> ContactsEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_corporation_contact_labels(
             access_token: &str,
-            corporation_id: i64;
+            corporation_id: i64
         ) -> Result<Vec<ContactLabel>, Error>
         url = "{}/corporations/{}/contacts/labels";
         label = "contact labels";

--- a/src/endpoints/contacts.rs
+++ b/src/endpoints/contacts.rs
@@ -111,61 +111,37 @@ impl<'a> ContactsEndpoints<'a> {
             .build();
     }
 
-    /// Delete list of contacts by ID for provided character ID
-    ///
-    /// For an overview & usage examples, see the [endpoints module documentation](super)
-    ///
-    /// # ESI Documentation
-    /// - <https://developers.eveonline.com/api-explorer#/operations/DeleteCharactersCharacterIdContacts>
-    ///
-    /// # Required Scopes
-    /// - [`CharactersScopes::write_contacts`](crate::scope::CharactersScopes::write_contacts):
-    ///   `esi-characters.write_contacts.v1`
-    ///
-    /// # Arguments
-    /// - `access_token`  (`&str`): Access token used for authenticated ESI routes in string format.
-    /// - `contact_ids`   (`Vec<i64>`): List of contact IDs to delete (up to 20 per request)
-    /// - `character_id`  (`i64`): The ID of the alliance to retrieve contacts labels for
-    ///
-    /// # Returns
-    /// Returns a [`Result`] containing either:
-    /// - `()`: No error if request was successful
-    /// - [`Error`]: An error if the fetch request fails
-    pub async fn delete_contacts(
-        &self,
-        access_token: &str,
-        contact_ids: Vec<i64>,
-        character_id: i64,
-    ) -> Result<(), Error> {
-        let contact_array_string = format!(
-            "[{}]",
-            contact_ids
-                .into_iter()
-                .map(|id| id.to_string())
-                .collect::<Vec<_>>()
-                .join(",")
-        );
-
-        let mut url = Url::parse(&format!(
-            "{}/characters/{}/contacts",
-            self.client.inner.esi_url, character_id
-        ))?;
-
-        {
-            let mut ser = Serializer::new(String::new());
-            ser.append_pair("contact_ids", &contact_array_string);
-            url.set_query(Some(&ser.finish()));
-        }
-
-        let required_scopes = ScopeBuilder::new()
+    define_endpoint! {
+        /// Delete list of contacts by ID for provided character ID
+        ///
+        /// For an overview & usage examples, see the [endpoints module documentation](super)
+        ///
+        /// # ESI Documentation
+        /// - <https://developers.eveonline.com/api-explorer#/operations/DeleteCharactersCharacterIdContacts>
+        ///
+        /// # Required Scopes
+        /// - [`CharactersScopes::write_contacts`](crate::scope::CharactersScopes::write_contacts):
+        ///   `esi-characters.write_contacts.v1`
+        ///
+        /// # Arguments
+        /// - `access_token`  (`&str`): Access token used for authenticated ESI routes in string format.
+        /// - `contact_ids`   (`Vec<i64>`): List of contact IDs to delete (up to 20 per request)
+        /// - `character_id`  (`i64`): The ID of the alliance to retrieve contacts labels for
+        ///
+        /// # Returns
+        /// Returns a [`Result`] containing either:
+        /// - `()`: No error if request was successful
+        /// - [`Error`]: An error if the fetch request fails
+        auth_delete delete_contacts(
+            access_token: &str,
+            character_id: i64;
+            contact_ids: Vec<i64>
+        ) -> Result<(), Error>
+        url = "{}/characters/{}/contacts";
+        label = "delete contacts";
+        required_scopes = ScopeBuilder::new()
             .characters(CharactersScopes::new().write_contacts())
             .build();
-
-        let esi = self.client.esi();
-        let api_call =
-            esi.delete_from_authenticated_esi::<()>(url.as_str(), access_token, required_scopes);
-
-        esi_common_impl!("delete contacts", url, api_call, (character_id))
     }
 
     define_endpoint! {

--- a/src/endpoints/contacts.rs
+++ b/src/endpoints/contacts.rs
@@ -125,8 +125,8 @@ impl<'a> ContactsEndpoints<'a> {
         ///
         /// # Arguments
         /// - `access_token`  (`&str`): Access token used for authenticated ESI routes in string format.
-        /// - `contact_ids`   (`Vec<i64>`): List of contact IDs to delete (up to 20 per request)
         /// - `character_id`  (`i64`): The ID of the alliance to retrieve contacts labels for
+        /// - `contact_ids`   (`Vec<i64>`): List of contact IDs to delete (up to 20 per request)
         ///
         /// # Returns
         /// Returns a [`Result`] containing either:

--- a/src/endpoints/contacts.rs
+++ b/src/endpoints/contacts.rs
@@ -71,7 +71,7 @@ impl<'a> ContactsEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_alliance_contacts(
             access_token: &str,
-            alliance_id: i64
+            alliance_id: i64;
         ) -> Result<Vec<AllianceContact>, Error>
         url = "{}/alliances/{}/contacts";
         label = "contacts";
@@ -102,7 +102,7 @@ impl<'a> ContactsEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_alliance_contact_labels(
             access_token: &str,
-            alliance_id: i64
+            alliance_id: i64;
         ) -> Result<Vec<ContactLabel>, Error>
         url = "{}/alliances/{}/contacts/labels";
         label = "contact labels";
@@ -166,7 +166,7 @@ impl<'a> ContactsEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_contacts(
             access_token: &str,
-            character_id: i64
+            character_id: i64;
         ) -> Result<Vec<CharacterContact>, Error>
         url = "{}/characters/{}/contacts";
         label = "contacts";
@@ -337,7 +337,7 @@ impl<'a> ContactsEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_contact_labels(
             access_token: &str,
-            character_id: i64
+            character_id: i64;
         ) -> Result<Vec<ContactLabel>, Error>
         url = "{}/characters/{}/contacts/labels";
         label = "contact labels";
@@ -368,7 +368,7 @@ impl<'a> ContactsEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_corporation_contacts(
             access_token: &str,
-            corporation_id: i64
+            corporation_id: i64;
         ) -> Result<Vec<CorporationContact>, Error>
         url = "{}/corporations/{}/contacts";
         label = "contacts";
@@ -399,7 +399,7 @@ impl<'a> ContactsEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_corporation_contact_labels(
             access_token: &str,
-            corporation_id: i64
+            corporation_id: i64;
         ) -> Result<Vec<ContactLabel>, Error>
         url = "{}/corporations/{}/contacts/labels";
         label = "contact labels";

--- a/src/endpoints/corporation.rs
+++ b/src/endpoints/corporation.rs
@@ -225,7 +225,7 @@ impl<'a> CorporationEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_corporation_divisions(
             access_token: &str,
-            corporation_id: i64;
+            corporation_id: i64
         ) -> Result<CorporationDivisions, Error>
         url = "{}/corporations/{}/divisions";
         label = "hangar & wallet divisions";
@@ -257,7 +257,7 @@ impl<'a> CorporationEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_corporation_facilities(
             access_token: &str,
-            corporation_id: i64;
+            corporation_id: i64
         ) -> Result<Vec<CorporationFacilities>, Error>
         url = "{}/corporations/{}/facilities";
         label = "industry facilities";
@@ -379,7 +379,7 @@ impl<'a> CorporationEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_corporation_members(
             access_token: &str,
-            corporation_id: i64;
+            corporation_id: i64
         ) -> Result<Vec<i64>, Error>
         url = "{}/corporations/{}/members";
         label = "character IDs of all members";
@@ -411,7 +411,7 @@ impl<'a> CorporationEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_corporation_member_limit(
             access_token: &str,
-            corporation_id: i64;
+            corporation_id: i64
         ) -> Result<i64, Error>
         url = "{}/corporations/{}/members/limit";
         label = "member limit";
@@ -443,7 +443,7 @@ impl<'a> CorporationEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_corporation_members_titles(
             access_token: &str,
-            corporation_id: i64;
+            corporation_id: i64
         ) -> Result<Vec<CorporationMemberTitles>, Error>
         url = "{}/corporations/{}/members/titles";
         label = "member titles";
@@ -476,7 +476,7 @@ impl<'a> CorporationEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get track_corporation_members(
             access_token: &str,
-            corporation_id: i64;
+            corporation_id: i64
         ) -> Result<Vec<CorporationMemberTracking>, Error>
         url = "{}/corporations/{}/membertracking";
         label = "member tracking";
@@ -509,7 +509,7 @@ impl<'a> CorporationEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_corporation_member_roles(
             access_token: &str,
-            corporation_id: i64;
+            corporation_id: i64
         ) -> Result<Vec<CorporationMemberRoles>, Error>
         url = "{}/corporations/{}/roles";
         label = "member roles";
@@ -745,7 +745,7 @@ impl<'a> CorporationEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_corporation_titles(
             access_token: &str,
-            corporation_id: i64;
+            corporation_id: i64
         ) -> Result<Vec<CorporationTitle>, Error>
         url = "{}/corporations/{}/titles";
         label = "titles";

--- a/src/endpoints/corporation.rs
+++ b/src/endpoints/corporation.rs
@@ -156,10 +156,10 @@ impl<'a> CorporationEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_corporation_blueprints(
             access_token: &str,
-            corporation_id: i64,
+            corporation_id: i64;
             page: i32
         ) -> Result<Vec<Blueprint>, Error>
-        url = "{}/corporations/{}/blueprints?page={}";
+        url = "{}/corporations/{}/blueprints";
         label = "blueprints";
         required_scopes = ScopeBuilder::new().corporations(CorporationsScopes::new().read_blueprints()).build();
     }
@@ -192,10 +192,10 @@ impl<'a> CorporationEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_all_corporation_alsc_logs(
             access_token: &str,
-            corporation_id: i64,
+            corporation_id: i64;
             page: i32
         ) -> Result<Vec<CorporationSecureContainerLog>, Error>
-        url = "{}/corporations/{}/containers/logs?page={}";
+        url = "{}/corporations/{}/containers/logs";
         label = "audit secure container log entries";
         required_scopes = ScopeBuilder::new().corporations(CorporationsScopes::new().read_container_logs()).build();
     }
@@ -225,7 +225,7 @@ impl<'a> CorporationEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_corporation_divisions(
             access_token: &str,
-            corporation_id: i64
+            corporation_id: i64;
         ) -> Result<CorporationDivisions, Error>
         url = "{}/corporations/{}/divisions";
         label = "hangar & wallet divisions";
@@ -257,7 +257,7 @@ impl<'a> CorporationEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_corporation_facilities(
             access_token: &str,
-            corporation_id: i64
+            corporation_id: i64;
         ) -> Result<Vec<CorporationFacilities>, Error>
         url = "{}/corporations/{}/facilities";
         label = "industry facilities";
@@ -312,10 +312,10 @@ impl<'a> CorporationEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_corporation_medals(
             access_token: &str,
-            corporation_id: i64,
+            corporation_id: i64;
             page: i32
         ) -> Result<Vec<CorporationMedal>, Error>
-        url = "{}/corporations/{}/medals?page={}";
+        url = "{}/corporations/{}/medals";
         label = "medals";
         required_scopes = ScopeBuilder::new().corporations(CorporationsScopes::new().read_medals()).build();
     }
@@ -349,10 +349,10 @@ impl<'a> CorporationEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_corporation_issued_medals(
             access_token: &str,
-            corporation_id: i64,
+            corporation_id: i64;
             page: i32
         ) -> Result<Vec<CorporationIssuedMedal>, Error>
-        url = "{}/corporations/{}/medals/issued?page={}";
+        url = "{}/corporations/{}/medals/issued";
         label = "medals";
         required_scopes = ScopeBuilder::new().corporations(CorporationsScopes::new().read_medals()).build();
     }
@@ -379,7 +379,7 @@ impl<'a> CorporationEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_corporation_members(
             access_token: &str,
-            corporation_id: i64
+            corporation_id: i64;
         ) -> Result<Vec<i64>, Error>
         url = "{}/corporations/{}/members";
         label = "character IDs of all members";
@@ -411,7 +411,7 @@ impl<'a> CorporationEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_corporation_member_limit(
             access_token: &str,
-            corporation_id: i64
+            corporation_id: i64;
         ) -> Result<i64, Error>
         url = "{}/corporations/{}/members/limit";
         label = "member limit";
@@ -443,7 +443,7 @@ impl<'a> CorporationEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_corporation_members_titles(
             access_token: &str,
-            corporation_id: i64
+            corporation_id: i64;
         ) -> Result<Vec<CorporationMemberTitles>, Error>
         url = "{}/corporations/{}/members/titles";
         label = "member titles";
@@ -476,7 +476,7 @@ impl<'a> CorporationEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get track_corporation_members(
             access_token: &str,
-            corporation_id: i64
+            corporation_id: i64;
         ) -> Result<Vec<CorporationMemberTracking>, Error>
         url = "{}/corporations/{}/membertracking";
         label = "member tracking";
@@ -509,7 +509,7 @@ impl<'a> CorporationEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_corporation_member_roles(
             access_token: &str,
-            corporation_id: i64
+            corporation_id: i64;
         ) -> Result<Vec<CorporationMemberRoles>, Error>
         url = "{}/corporations/{}/roles";
         label = "member roles";
@@ -543,10 +543,10 @@ impl<'a> CorporationEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_corporation_member_roles_history(
             access_token: &str,
-            corporation_id: i64,
+            corporation_id: i64;
             page: i32
         ) -> Result<Vec<CorporationMemberRolesHistory>, Error>
-        url = "{}/corporations/{}/roles/history?page={}";
+        url = "{}/corporations/{}/roles/history";
         label = "member roles";
         required_scopes = ScopeBuilder::new().corporations(CorporationsScopes::new().read_corporation_membership()).build();
     }
@@ -577,10 +577,10 @@ impl<'a> CorporationEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_corporation_shareholders(
             access_token: &str,
-            corporation_id: i64,
+            corporation_id: i64;
             page: i32
         ) -> Result<Vec<CorporationShareholder>, Error>
-        url = "{}/corporations/{}/shareholders?page={}";
+        url = "{}/corporations/{}/shareholders";
         label = "shareholders";
         required_scopes = ScopeBuilder::new().wallet(WalletScopes::new().read_corporation_wallets()).build();
     }
@@ -608,10 +608,10 @@ impl<'a> CorporationEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_corporation_standings(
             access_token: &str,
-            corporation_id: i64,
+            corporation_id: i64;
             page: i32
         ) -> Result<Vec<Standing>, Error>
-        url = "{}/corporations/{}/standings?page={}";
+        url = "{}/corporations/{}/standings";
         label = "NPC standings";
         required_scopes = ScopeBuilder::new().corporations(CorporationsScopes::new().read_standings()).build();
     }
@@ -642,10 +642,10 @@ impl<'a> CorporationEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_corporation_starbases(
             access_token: &str,
-            corporation_id: i64,
+            corporation_id: i64;
             page: i32
         ) -> Result<Vec<CorporationStarbase>, Error>
-        url = "{}/corporations/{}/starbases?page={}";
+        url = "{}/corporations/{}/starbases";
         label = "starbases (POSes)";
         required_scopes = ScopeBuilder::new().corporations(CorporationsScopes::new().read_starbases()).build();
     }
@@ -678,10 +678,10 @@ impl<'a> CorporationEndpoints<'a> {
         auth_get get_starbase_detail(
             access_token: &str,
             corporation_id: i64,
-            starbase_id: i64,
+            starbase_id: i64;
             system_id: i64
         ) -> Result<CorporationStarbaseDetails, Error>
-        url = "{}/corporations/{}/starbases/{}?system_id={}";
+        url = "{}/corporations/{}/starbases/{}";
         label = "a starbase's (POS) details";
         required_scopes = ScopeBuilder::new().corporations(CorporationsScopes::new().read_starbases()).build();
     }
@@ -712,10 +712,10 @@ impl<'a> CorporationEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_corporation_structures(
             access_token: &str,
-            corporation_id: i64,
+            corporation_id: i64;
             page: i32
         ) -> Result<Vec<CorporationStructure>, Error>
-        url = "{}/corporations/{}/structures?page={}";
+        url = "{}/corporations/{}/structures";
         label = "structures";
         required_scopes = ScopeBuilder::new().corporations(CorporationsScopes::new().read_structures()).build();
     }
@@ -745,7 +745,7 @@ impl<'a> CorporationEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get get_corporation_titles(
             access_token: &str,
-            corporation_id: i64
+            corporation_id: i64;
         ) -> Result<Vec<CorporationTitle>, Error>
         url = "{}/corporations/{}/titles";
         label = "titles";

--- a/src/endpoints/macros/endpoint.rs
+++ b/src/endpoints/macros/endpoint.rs
@@ -158,21 +158,37 @@ macro_rules! define_endpoint {
         auth_delete $fn_name:ident(
             $(&self,)?
             access_token: &str,
-            $($param_name:ident: $param_type:ty),* $(,)?
+            $($path_name:ident: $path_type:ty),* $(,)? ;
+            $($query_name:ident: $query_type:ty),* $(,)?
         ) -> Result<$return_type:ty, Error>
         url = $url:expr;
         label = $label:expr;
         required_scopes = $required_scopes:expr;
     ) => {
         $(#[$attr])*
-        pub async fn $fn_name(&self, access_token: &str, $($param_name: $param_type),*) -> Result<$return_type, Error> {
-            let url = format!($url, self.client.inner.esi_url, $($param_name),*);
+        pub async fn $fn_name(&self, access_token: &str, $($path_name: $path_type),*, $($query_name: $query_type),*) -> Result<$return_type, Error> {
+            let mut url = url::Url::parse(&format!(
+                $url, self.client.inner.esi_url, $($path_name),*
+            ))?;
+
+            // Add query params
+            {
+                let mut ser = url::form_urlencoded::Serializer::new(String::new());
+
+                $(
+                    let val = serde_json::to_string(&$query_name).map_err(|e| Error::from(e))?;
+
+                    ser.append_pair(stringify!($query_name), &val);
+                )*
+
+                url.set_query(Some(&ser.finish()));
+            }
 
             let esi = self.client.esi();
             let api_call = esi
-                .delete_from_authenticated_esi::<$return_type>(&url, &access_token, $required_scopes);
+                .delete_from_authenticated_esi::<$return_type>(url.as_str(), &access_token, $required_scopes);
 
-            esi_common_impl!($label, url, api_call, ($($param_name),*))
+            esi_common_impl!($label, url, api_call, ($($path_name),*))
         }
     };
 }

--- a/src/endpoints/macros/endpoint.rs
+++ b/src/endpoints/macros/endpoint.rs
@@ -83,21 +83,41 @@ macro_rules! define_endpoint {
         auth_get $fn_name:ident(
             $(&self,)?
             access_token: &str,
-            $($param_name:ident: $param_type:ty),* $(,)?
+            $($path_name:ident: $path_type:ty),* $(,)? ;
+            $($query_name:ident: $query_type:ty),* $(,)?
         ) -> Result<$return_type:ty, Error>
         url = $url:expr;
         label = $label:expr;
         required_scopes = $required_scopes:expr;
     ) => {
         $(#[$attr])*
-        pub async fn $fn_name(&self, access_token: &str, $($param_name: $param_type),*) -> Result<$return_type, Error> {
-            let url = format!($url, self.client.inner.esi_url, $($param_name),*);
+        pub async fn $fn_name(&self, access_token: &str, $($path_name: $path_type),*, $($query_name: $query_type),*) -> Result<$return_type, Error> {
+            // Add URL path params
+            let mut url = url::Url::parse(&format!(
+                $url, self.client.inner.esi_url, $($path_name),*
+            ))?;
+
+            // Add query params
+            {
+                let mut ser = url::form_urlencoded::Serializer::new(String::new());
+
+                $(
+                    let val = serde_json::to_string(&$query_name).map_err(|e| Error::from(e))?;
+
+                    ser.append_pair(stringify!($query_name), &val);
+                )*
+
+                let q = ser.finish();
+                if !q.is_empty() {
+                    url.set_query(Some(&q));
+                }
+            }
 
             let esi = self.client.esi();
             let api_call = esi
-                .get_from_authenticated_esi::<$return_type>(&url, &access_token, $required_scopes);
+                .get_from_authenticated_esi::<$return_type>(url.as_str(), access_token, $required_scopes);
 
-            esi_common_impl!($label, url, api_call, ($($param_name),*))
+            esi_common_impl!($label, url, api_call, ($($path_name),*))
         }
     };
 

--- a/src/endpoints/macros/endpoint.rs
+++ b/src/endpoints/macros/endpoint.rs
@@ -60,20 +60,44 @@ macro_rules! define_endpoint {
         pub_post $fn_name:ident(
             $(&self,)?
             $body_name:ident: $body_type:ty,
-            $($param_name:ident: $param_type:ty),* $(,)?
+            $($path_name:ident: $path_ty:ty),* $(,)?
+            $(; $($query_name:ident: $query_ty:ty),* $(,)?)?
         ) -> Result<$return_type:ty, Error>
         url = $url:expr;
         label = $label:expr;
     ) => {
         $(#[$attr])*
-        pub async fn $fn_name(&self, $body_name: $body_type, $($param_name: $param_type),*) -> Result<$return_type, Error> {
-            let url = format!($url, self.client.inner.esi_url, $($param_name),*);
+        pub async fn $fn_name(&self, $body_name: $body_type, $(, $($path_name: $path_ty),* )? $(, $($query_name: $query_ty),* )? ) -> Result<$return_type, Error> {
+            // Add URL path params
+            let url = url::Url::parse(&format!(
+                $url, self.client.inner.esi_url, $($path_name),*
+            ))?;
+
+            // Add query params
+            $(
+                let mut url = url;
+
+                {
+                    let mut ser = url::form_urlencoded::Serializer::new(String::new());
+
+                        $(
+                            let val = serde_json::to_string(&$query_name).map_err(|e| Error::from(e))?;
+
+                            ser.append_pair(stringify!($query_name), &val);
+                        )*
+
+                    let q = ser.finish();
+                    if !q.is_empty() {
+                        url.set_query(Some(&q));
+                    }
+                }
+            )?
 
             let esi = self.client.esi();
             let api_call = esi
-                .post_to_public_esi::<$return_type, $body_type>(&url, &$body_name);
+                .post_to_public_esi::<$return_type, $body_type>(url.as_str(), &$body_name);
 
-            esi_common_impl!($label, url, api_call, ($($param_name),*))
+            esi_common_impl!($label, url, api_call, ($($path_name),*))
         }
     };
 

--- a/src/endpoints/macros/endpoint.rs
+++ b/src/endpoints/macros/endpoint.rs
@@ -30,6 +30,29 @@ macro_rules! esi_common_impl {
     };
 }
 
+macro_rules! build_endpoint_url {
+    // No query params
+    ($self_ident:ident, $fmt:expr, ($($path:ident),* $(,)?)) => {{
+        url::Url::parse(&format!($fmt, $self_ident.client.inner.esi_url, $($path),* ))?
+    }};
+
+    // One or more query params
+    ($self_ident:ident, $fmt:expr, ($($path:ident),* $(,)?), ($($query:ident),+ $(,)?)) => {{
+        let mut url = url::Url::parse(&format!($fmt, $self_ident.client.inner.esi_url, $($path),* ))?;
+
+        let mut ser = url::form_urlencoded::Serializer::new(String::new());
+
+        $(
+            let val = serde_json::to_string(&$query).map_err(|e| Error::from(e))?;
+            ser.append_pair(stringify!($query), &val);
+        )*
+
+        url.set_query(Some(&ser.finish()));
+
+        url
+    }};
+}
+
 // Macro for defining public & authenticated ESI endpoints
 macro_rules! define_endpoint {
     // GET endpoint macro
@@ -45,30 +68,7 @@ macro_rules! define_endpoint {
     ) => {
         $(#[$attr])*
         pub async fn $fn_name(&self, $($path_name: $path_ty),*  $(, $($query_name: $query_ty),* )? ) -> Result<$return_type, Error> {
-            // Add URL path params
-            let url = url::Url::parse(&format!(
-                $url, self.client.inner.esi_url, $($path_name),*
-            ))?;
-
-            // Add query params
-            $(
-                let mut url = url;
-
-                {
-                    let mut ser = url::form_urlencoded::Serializer::new(String::new());
-
-                        $(
-                            let val = serde_json::to_string(&$query_name).map_err(|e| Error::from(e))?;
-
-                            ser.append_pair(stringify!($query_name), &val);
-                        )*
-
-                    let q = ser.finish();
-                    if !q.is_empty() {
-                        url.set_query(Some(&q));
-                    }
-                }
-            )?
+            let url = build_endpoint_url!(self, $url, ($($path_name),*) $(, ($($query_name),*) )? );
 
             let esi = self.client.esi();
             let api_call = esi
@@ -92,30 +92,7 @@ macro_rules! define_endpoint {
     ) => {
         $(#[$attr])*
         pub async fn $fn_name(&self, $body_name: $body_type, $($path_name: $path_ty),*  $(, $($query_name: $query_ty),* )? ) -> Result<$return_type, Error> {
-            // Add URL path params
-            let url = url::Url::parse(&format!(
-                $url, self.client.inner.esi_url, $($path_name),*
-            ))?;
-
-            // Add query params
-            $(
-                let mut url = url;
-
-                {
-                    let mut ser = url::form_urlencoded::Serializer::new(String::new());
-
-                        $(
-                            let val = serde_json::to_string(&$query_name).map_err(|e| Error::from(e))?;
-
-                            ser.append_pair(stringify!($query_name), &val);
-                        )*
-
-                    let q = ser.finish();
-                    if !q.is_empty() {
-                        url.set_query(Some(&q));
-                    }
-                }
-            )?
+            let url = build_endpoint_url!(self, $url, ($($path_name),*) $(, ($($query_name),*) )? );
 
             let esi = self.client.esi();
             let api_call = esi
@@ -140,30 +117,7 @@ macro_rules! define_endpoint {
     ) => {
         $(#[$attr])*
         pub async fn $fn_name(&self, access_token: &str, $($path_name: $path_ty),*  $(, $($query_name: $query_ty),* )? ) -> Result<$return_type, Error> {
-            // Add URL path params
-            let url = url::Url::parse(&format!(
-                $url, self.client.inner.esi_url, $($path_name),*
-            ))?;
-
-            // Add query params
-            $(
-                let mut url = url;
-
-                {
-                    let mut ser = url::form_urlencoded::Serializer::new(String::new());
-
-                        $(
-                            let val = serde_json::to_string(&$query_name).map_err(|e| Error::from(e))?;
-
-                            ser.append_pair(stringify!($query_name), &val);
-                        )*
-
-                    let q = ser.finish();
-                    if !q.is_empty() {
-                        url.set_query(Some(&q));
-                    }
-                }
-            )?
+            let url = build_endpoint_url!(self, $url, ($($path_name),*) $(, ($($query_name),*) )? );
 
             let esi = self.client.esi();
             let api_call = esi
@@ -189,30 +143,7 @@ macro_rules! define_endpoint {
     ) => {
         $(#[$attr])*
         pub async fn $fn_name(&self, access_token: &str, $body_name: $body_type, $($path_name: $path_ty),*  $(, $($query_name: $query_ty),* )? ) -> Result<$return_type, Error> {
-            // Add URL path params
-            let url = url::Url::parse(&format!(
-                $url, self.client.inner.esi_url, $($path_name),*
-            ))?;
-
-            // Add query params
-            $(
-                let mut url = url;
-
-                {
-                    let mut ser = url::form_urlencoded::Serializer::new(String::new());
-
-                        $(
-                            let val = serde_json::to_string(&$query_name).map_err(|e| Error::from(e))?;
-
-                            ser.append_pair(stringify!($query_name), &val);
-                        )*
-
-                    let q = ser.finish();
-                    if !q.is_empty() {
-                        url.set_query(Some(&q));
-                    }
-                }
-            )?
+            let url = build_endpoint_url!(self, $url, ($($path_name),*) $(, ($($query_name),*) )? );
 
             let esi = self.client.esi();
             let api_call = esi
@@ -238,30 +169,7 @@ macro_rules! define_endpoint {
     ) => {
         $(#[$attr])*
         pub async fn $fn_name(&self, access_token: &str, $body_name: $body_type, $($path_name: $path_ty),*  $(, $($query_name: $query_ty),* )? ) -> Result<$return_type, Error> {
-            // Add URL path params
-            let url = url::Url::parse(&format!(
-                $url, self.client.inner.esi_url, $($path_name),*
-            ))?;
-
-            // Add query params
-            $(
-                let mut url = url;
-
-                {
-                    let mut ser = url::form_urlencoded::Serializer::new(String::new());
-
-                        $(
-                            let val = serde_json::to_string(&$query_name).map_err(|e| Error::from(e))?;
-
-                            ser.append_pair(stringify!($query_name), &val);
-                        )*
-
-                    let q = ser.finish();
-                    if !q.is_empty() {
-                        url.set_query(Some(&q));
-                    }
-                }
-            )?
+            let url = build_endpoint_url!(self, $url, ($($path_name),*) $(, ($($query_name),*) )? );
 
             let esi = self.client.esi();
             let api_call = esi
@@ -287,30 +195,7 @@ macro_rules! define_endpoint {
     ) => {
         $(#[$attr])*
         pub async fn $fn_name(&self, access_token: &str, $($path_name: $path_ty),*  $(, $($query_name: $query_ty),* )? ) -> Result<$return_type, Error> {
-            // Add URL path params
-            let url = url::Url::parse(&format!(
-                $url, self.client.inner.esi_url, $($path_name),*
-            ))?;
-
-            // Add query params
-            $(
-                let mut url = url;
-
-                {
-                    let mut ser = url::form_urlencoded::Serializer::new(String::new());
-
-                        $(
-                            let val = serde_json::to_string(&$query_name).map_err(|e| Error::from(e))?;
-
-                            ser.append_pair(stringify!($query_name), &val);
-                        )*
-
-                    let q = ser.finish();
-                    if !q.is_empty() {
-                        url.set_query(Some(&q));
-                    }
-                }
-            )?
+            let url = build_endpoint_url!(self, $url, ($($path_name),*) $(, ($($query_name),*) )? );
 
             let esi = self.client.esi();
             let api_call = esi

--- a/src/endpoints/macros/endpoint.rs
+++ b/src/endpoints/macros/endpoint.rs
@@ -1,4 +1,4 @@
-// Common macro for handling the shared implementation parts
+/// Common macro for handling the ESI endpoint parts
 macro_rules! esi_common_impl {
     (
         $label:expr,
@@ -30,6 +30,7 @@ macro_rules! esi_common_impl {
     };
 }
 
+/// Macro for constructing an ESI endpoint request URL
 macro_rules! build_endpoint_url {
     // No query params
     ($self_ident:ident, $fmt:expr, ($($path:ident),* $(,)?)) => {{
@@ -53,7 +54,9 @@ macro_rules! build_endpoint_url {
     }};
 }
 
-// Macro for defining public & authenticated ESI endpoints
+/// Macro for defining public & authenticated ESI endpoints
+///
+/// For an overview of methods and a usage example, please see the [module-level documentation](super)
 macro_rules! define_endpoint {
     // GET endpoint macro
     (

--- a/src/endpoints/macros/endpoint.rs
+++ b/src/endpoints/macros/endpoint.rs
@@ -91,7 +91,7 @@ macro_rules! define_endpoint {
         label = $label:expr;
     ) => {
         $(#[$attr])*
-        pub async fn $fn_name(&self, $body_name: $body_type, $(, $($path_name: $path_ty),* )? $(, $($query_name: $query_ty),* )? ) -> Result<$return_type, Error> {
+        pub async fn $fn_name(&self, $body_name: $body_type, $($path_name: $path_ty),*  $(, $($query_name: $query_ty),* )? ) -> Result<$return_type, Error> {
             // Add URL path params
             let url = url::Url::parse(&format!(
                 $url, self.client.inner.esi_url, $($path_name),*
@@ -131,35 +131,39 @@ macro_rules! define_endpoint {
         auth_get $fn_name:ident(
             $(&self,)?
             access_token: &str,
-            $($path_name:ident: $path_type:ty),* $(,)? ;
-            $($query_name:ident: $query_type:ty),* $(,)?
+            $($path_name:ident: $path_ty:ty),* $(,)?
+            $(; $($query_name:ident: $query_ty:ty),* $(,)?)?
         ) -> Result<$return_type:ty, Error>
         url = $url:expr;
         label = $label:expr;
         required_scopes = $required_scopes:expr;
     ) => {
         $(#[$attr])*
-        pub async fn $fn_name(&self, access_token: &str, $($path_name: $path_type),*, $($query_name: $query_type),*) -> Result<$return_type, Error> {
+        pub async fn $fn_name(&self, access_token: &str, $($path_name: $path_ty),*  $(, $($query_name: $query_ty),* )? ) -> Result<$return_type, Error> {
             // Add URL path params
-            let mut url = url::Url::parse(&format!(
+            let url = url::Url::parse(&format!(
                 $url, self.client.inner.esi_url, $($path_name),*
             ))?;
 
             // Add query params
-            {
-                let mut ser = url::form_urlencoded::Serializer::new(String::new());
+            $(
+                let mut url = url;
 
-                $(
-                    let val = serde_json::to_string(&$query_name).map_err(|e| Error::from(e))?;
+                {
+                    let mut ser = url::form_urlencoded::Serializer::new(String::new());
 
-                    ser.append_pair(stringify!($query_name), &val);
-                )*
+                        $(
+                            let val = serde_json::to_string(&$query_name).map_err(|e| Error::from(e))?;
 
-                let q = ser.finish();
-                if !q.is_empty() {
-                    url.set_query(Some(&q));
+                            ser.append_pair(stringify!($query_name), &val);
+                        )*
+
+                    let q = ser.finish();
+                    if !q.is_empty() {
+                        url.set_query(Some(&q));
+                    }
                 }
-            }
+            )?
 
             let esi = self.client.esi();
             let api_call = esi
@@ -176,35 +180,39 @@ macro_rules! define_endpoint {
             $(&self,)?
             access_token: &str,
             $body_name:ident: $body_type:ty,
-            $($path_name:ident: $path_type:ty),* $(,)? ;
-            $($query_name:ident: $query_type:ty),* $(,)?
+            $($path_name:ident: $path_ty:ty),* $(,)?
+            $(; $($query_name:ident: $query_ty:ty),* $(,)?)?
         ) -> Result<$return_type:ty, Error>
         url = $url:expr;
         label = $label:expr;
         required_scopes = $required_scopes:expr;
     ) => {
         $(#[$attr])*
-        pub async fn $fn_name(&self, access_token: &str, $body_name: $body_type, $($path_name: $path_type),*, $($query_name: $query_type),*) -> Result<$return_type, Error> {
+        pub async fn $fn_name(&self, access_token: &str, $body_name: $body_type, $($path_name: $path_ty),*  $(, $($query_name: $query_ty),* )? ) -> Result<$return_type, Error> {
             // Add URL path params
-            let mut url = url::Url::parse(&format!(
+            let url = url::Url::parse(&format!(
                 $url, self.client.inner.esi_url, $($path_name),*
             ))?;
 
             // Add query params
-            {
-                let mut ser = url::form_urlencoded::Serializer::new(String::new());
+            $(
+                let mut url = url;
 
-                $(
-                    let val = serde_json::to_string(&$query_name).map_err(|e| Error::from(e))?;
+                {
+                    let mut ser = url::form_urlencoded::Serializer::new(String::new());
 
-                    ser.append_pair(stringify!($query_name), &val);
-                )*
+                        $(
+                            let val = serde_json::to_string(&$query_name).map_err(|e| Error::from(e))?;
 
-                let q = ser.finish();
-                if !q.is_empty() {
-                    url.set_query(Some(&q));
+                            ser.append_pair(stringify!($query_name), &val);
+                        )*
+
+                    let q = ser.finish();
+                    if !q.is_empty() {
+                        url.set_query(Some(&q));
+                    }
                 }
-            }
+            )?
 
             let esi = self.client.esi();
             let api_call = esi
@@ -221,35 +229,39 @@ macro_rules! define_endpoint {
             $(&self,)?
             access_token: &str,
             $body_name:ident: $body_type:ty,
-            $($path_name:ident: $path_type:ty),* $(,)? ;
-            $($query_name:ident: $query_type:ty),* $(,)?
+            $($path_name:ident: $path_ty:ty),* $(,)?
+            $(; $($query_name:ident: $query_ty:ty),* $(,)?)?
         ) -> Result<$return_type:ty, Error>
         url = $url:expr;
         label = $label:expr;
         required_scopes = $required_scopes:expr;
     ) => {
         $(#[$attr])*
-        pub async fn $fn_name(&self, access_token: &str, $body_name: $body_type, $($path_name: $path_type),*, $($query_name: $query_type),*) -> Result<$return_type, Error> {
+        pub async fn $fn_name(&self, access_token: &str, $body_name: $body_type, $($path_name: $path_ty),*  $(, $($query_name: $query_ty),* )? ) -> Result<$return_type, Error> {
             // Add URL path params
-            let mut url = url::Url::parse(&format!(
+            let url = url::Url::parse(&format!(
                 $url, self.client.inner.esi_url, $($path_name),*
             ))?;
 
             // Add query params
-            {
-                let mut ser = url::form_urlencoded::Serializer::new(String::new());
+            $(
+                let mut url = url;
 
-                $(
-                    let val = serde_json::to_string(&$query_name).map_err(|e| Error::from(e))?;
+                {
+                    let mut ser = url::form_urlencoded::Serializer::new(String::new());
 
-                    ser.append_pair(stringify!($query_name), &val);
-                )*
+                        $(
+                            let val = serde_json::to_string(&$query_name).map_err(|e| Error::from(e))?;
 
-                let q = ser.finish();
-                if !q.is_empty() {
-                    url.set_query(Some(&q));
+                            ser.append_pair(stringify!($query_name), &val);
+                        )*
+
+                    let q = ser.finish();
+                    if !q.is_empty() {
+                        url.set_query(Some(&q));
+                    }
                 }
-            }
+            )?
 
             let esi = self.client.esi();
             let api_call = esi
@@ -266,35 +278,39 @@ macro_rules! define_endpoint {
         auth_delete $fn_name:ident(
             $(&self,)?
             access_token: &str,
-            $($path_name:ident: $path_type:ty),* $(,)? ;
-            $($query_name:ident: $query_type:ty),* $(,)?
+            $($path_name:ident: $path_ty:ty),* $(,)?
+            $(; $($query_name:ident: $query_ty:ty),* $(,)?)?
         ) -> Result<$return_type:ty, Error>
         url = $url:expr;
         label = $label:expr;
         required_scopes = $required_scopes:expr;
     ) => {
         $(#[$attr])*
-        pub async fn $fn_name(&self, access_token: &str, $($path_name: $path_type),*, $($query_name: $query_type),*) -> Result<$return_type, Error> {
+        pub async fn $fn_name(&self, access_token: &str, $($path_name: $path_ty),*  $(, $($query_name: $query_ty),* )? ) -> Result<$return_type, Error> {
             // Add URL path params
-            let mut url = url::Url::parse(&format!(
+            let url = url::Url::parse(&format!(
                 $url, self.client.inner.esi_url, $($path_name),*
             ))?;
 
             // Add query params
-            {
-                let mut ser = url::form_urlencoded::Serializer::new(String::new());
+            $(
+                let mut url = url;
 
-                $(
-                    let val = serde_json::to_string(&$query_name).map_err(|e| Error::from(e))?;
+                {
+                    let mut ser = url::form_urlencoded::Serializer::new(String::new());
 
-                    ser.append_pair(stringify!($query_name), &val);
-                )*
+                        $(
+                            let val = serde_json::to_string(&$query_name).map_err(|e| Error::from(e))?;
 
-                let q = ser.finish();
-                if !q.is_empty() {
-                    url.set_query(Some(&q));
+                            ser.append_pair(stringify!($query_name), &val);
+                        )*
+
+                    let q = ser.finish();
+                    if !q.is_empty() {
+                        url.set_query(Some(&q));
+                    }
                 }
-            }
+            )?
 
             let esi = self.client.esi();
             let api_call = esi

--- a/src/endpoints/macros/endpoint.rs
+++ b/src/endpoints/macros/endpoint.rs
@@ -108,21 +108,41 @@ macro_rules! define_endpoint {
             $(&self,)?
             access_token: &str,
             $body_name:ident: $body_type:ty,
-            $($param_name:ident: $param_type:ty),* $(,)?
+            $($path_name:ident: $path_type:ty),* $(,)? ;
+            $($query_name:ident: $query_type:ty),* $(,)?
         ) -> Result<$return_type:ty, Error>
         url = $url:expr;
         label = $label:expr;
         required_scopes = $required_scopes:expr;
     ) => {
         $(#[$attr])*
-        pub async fn $fn_name(&self, access_token: &str, $body_name: $body_type, $($param_name: $param_type),*) -> Result<$return_type, Error> {
-            let url = format!($url, self.client.inner.esi_url, $($param_name),*);
+        pub async fn $fn_name(&self, access_token: &str, $body_name: $body_type, $($path_name: $path_type),*, $($query_name: $query_type),*) -> Result<$return_type, Error> {
+            // Add URL path params
+            let mut url = url::Url::parse(&format!(
+                $url, self.client.inner.esi_url, $($path_name),*
+            ))?;
+
+            // Add query params
+            {
+                let mut ser = url::form_urlencoded::Serializer::new(String::new());
+
+                $(
+                    let val = serde_json::to_string(&$query_name).map_err(|e| Error::from(e))?;
+
+                    ser.append_pair(stringify!($query_name), &val);
+                )*
+
+                let q = ser.finish();
+                if !q.is_empty() {
+                    url.set_query(Some(&q));
+                }
+            }
 
             let esi = self.client.esi();
             let api_call = esi
-                .post_to_authenticated_esi::<$return_type, $body_type>(&url, &$body_name, &access_token, $required_scopes);
+                .post_to_authenticated_esi::<$return_type, $body_type>(url.as_str(), &$body_name, access_token, $required_scopes);
 
-            esi_common_impl!($label, url, api_call, ($($param_name),*))
+            esi_common_impl!($label, url, api_call, ($($path_name),*))
         }
     };
 

--- a/src/endpoints/macros/mod.rs
+++ b/src/endpoints/macros/mod.rs
@@ -1,6 +1,71 @@
-//! # EVE ESI Endpoint Macros
+//! # EVE ESI Endpoint Request Macros
 //!
-//! Macros used for defining ESI endpoints to reduce repetition.
+//! Provides the `define_endpoint!` macro which is used to concisely define ESI endpoints in a way that only includes
+//! the info that varies between each endpoints.
+//!
+//! During compilation this macro is then expanded into an actual function which includes all the necessary logic to
+//! build an ESI request URL with path & query parameters, making the request with an HTTP client, and handling
+//! logging of any debug, info, and error messages related to the request.
+//!
+//! ## Endpoint Variants
+//!
+//! | Variant        | Required Arguments                      |
+//! | -------------- | --------------------------------------- |
+//! | `pub_get`      |                                         |
+//! | `pub_post`     | `body_name: body_type`                  |
+//! | `auth_get`     | `&access_token`                         |
+//! | `auth_post`    | `&access_token`, `body_name: body_type` |
+//! | `auth_put`     | `&access_token`, `body_name: body_type` |
+//! | `auth_delete`  | `&access_token`                         |
+//!
+//! ## Usage
+//!
+//! Use the already defined endpoints with `define_endpoint!` as a guideline as to how it varies between the different
+//! request types, for example public requests do not utilize an `access_token` or `required_scopes`.
+//!
+//! The `define_endpoint!` macro must be defined as an impl of a struct which contains a `client` field with the type
+//! `&'a Client` (The [`crate::Client`]).
+//!
+//! ### URL Path & Query Parameters
+//! The `define_endpoint!` macro is flexible when it comes to URL parameters in that it permits not having any path
+//! or query parameters at all, only path parameters, only query parameters, or both.
+//! - Following the `access_token` for authenticated endpoints & any POST/PUT body (e.g. `contact_ids` in the example below),
+//! the path parameters are then defined.
+//! - A `;` is used as a delimiter to denote where the required endpoint method arguments & path parameters end and the query paramters begin
+//!
+//! ### Example
+//!
+//! ```ignore
+//! define_endpoint! {
+//!     // Any function documentation will go here
+//!     /// Example function documentation starting with `///`
+//!     // Set the endpoint variant to `auth_post` for an authenticated POST request
+//!     // Set function to be named as `add_contacts`
+//!     auth_post add_contacts(
+//!         // Set access_token argument required for all authenticated routes
+//!         access_token: &str,
+//!         // Set post request body argument
+//!         contact_ids: Vec<i64>,
+//!         // Set URL path parameter argument
+//!         // The `;` marks the end of the URL path parameters and the start of the query parameters
+//!         character_id: i64;
+//!         // Set URL query parameter arguments
+//!         standing: f64,
+//!         label_ids: Vec<i64>,
+//!         watched: bool,
+//!     // Set return type for the function
+//!     ) -> Result<Vec<i64>, Error>
+//! // Set the endpoint URL with `{}` representing the path parameters
+//! url = "{}/characters/{}/contacts";
+//! // Set the label text used in logging messages
+//! label = "add contacts";
+//! // Set the required ESI scopes to be checked for when access token is validated prior to request
+//! // This prevents incurring ESI rate limits by preventing potential errors on the client side
+//! required_scopes =  ScopeBuilder::new()
+//!     .characters(CharactersScopes::new().write_contacts())
+//!     .build();
+//! }
+//! ```
 
 #[macro_use]
 mod logging;

--- a/src/endpoints/market.rs
+++ b/src/endpoints/market.rs
@@ -143,7 +143,7 @@ impl<'a> MarketEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get list_open_orders_from_a_corporation(
             access_token: &str,
-            corporation_id: i64;
+            corporation_id: i64
         ) -> Result<Vec<CorporationMarketOrder>, Error>
         url = "{}/corporations/{}/orders";
         label = "open orders";

--- a/src/endpoints/market.rs
+++ b/src/endpoints/market.rs
@@ -80,7 +80,7 @@ impl<'a> MarketEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get list_open_orders_from_a_character(
             access_token: &str,
-            character_id: i64
+            character_id: i64;
         ) -> Result<Vec<CharacterMarketOrder>, Error>
         url = "{}/characters/{}/orders";
         label = "open market orders";
@@ -110,10 +110,10 @@ impl<'a> MarketEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get list_historical_orders_by_a_character(
             access_token: &str,
-            character_id: i64,
-            page: i32,
+            character_id: i64;
+            page: i32
         ) -> Result<Vec<CharacterMarketOrder>, Error>
-        url = "{}/characters/{}/orders/history?page={}";
+        url = "{}/characters/{}/orders/history";
         label = "historical orders";
         required_scopes = ScopeBuilder::new().markets(MarketsScopes::new().read_character_orders()).build();
     }
@@ -143,7 +143,7 @@ impl<'a> MarketEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get list_open_orders_from_a_corporation(
             access_token: &str,
-            corporation_id: i64
+            corporation_id: i64;
         ) -> Result<Vec<CorporationMarketOrder>, Error>
         url = "{}/corporations/{}/orders";
         label = "open orders";
@@ -176,10 +176,10 @@ impl<'a> MarketEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get list_historical_orders_from_a_corporation(
             access_token: &str,
-            corporation_d: i64,
-            page: i32,
+            corporation_d: i64;
+            page: i32
         ) -> Result<Vec<CorporationMarketOrder>, Error>
-        url = "{}/corporations/{}/orders/history?page={}";
+        url = "{}/corporations/{}/orders/history";
         label = "historical orders";
         required_scopes = ScopeBuilder::new().markets(MarketsScopes::new().read_corporation_orders()).build();
     }
@@ -265,10 +265,10 @@ impl<'a> MarketEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get list_orders_in_a_structure(
             access_token: &str,
-            structure_id: i64,
-            page: i32,
+            structure_id: i64;
+            page: i32
         ) -> Result<Vec<StructureMarketOrder>, Error>
-        url = "{}/markets/structures/{}?page={}";
+        url = "{}/markets/structures/{}";
         label = "market orders";
         required_scopes = ScopeBuilder::new().markets(MarketsScopes::new().structure_markets()).build();
     }

--- a/src/endpoints/market.rs
+++ b/src/endpoints/market.rs
@@ -80,7 +80,7 @@ impl<'a> MarketEndpoints<'a> {
         /// - [`Error`]: An error if the fetch request fails
         auth_get list_open_orders_from_a_character(
             access_token: &str,
-            character_id: i64;
+            character_id: i64
         ) -> Result<Vec<CharacterMarketOrder>, Error>
         url = "{}/characters/{}/orders";
         label = "open market orders";
@@ -315,11 +315,11 @@ impl<'a> MarketEndpoints<'a> {
         /// Returns a [`Result`] containing either:
         /// - `Vec<`[`MarketRegionOrder`]`>`: list of market orders within the provided region ID and of the specified order type
         pub_get list_orders_in_a_region(
-            region_id: i64,
+            region_id: i64;
             order_type: OrderType,
             page: i32
         ) -> Result<Vec<MarketRegionOrder>, Error>
-        url = "{}/markets/{}/orders?order_type={}&page={}";
+        url = "{}/markets/{}/orders";
         label = "market orders";
     }
 
@@ -339,10 +339,10 @@ impl<'a> MarketEndpoints<'a> {
         /// Returns a [`Result`] containing either:
         /// - `Vec<i64>`: list of type IDs that have active market orders for the given region ID
         pub_get list_type_ids_relevant_to_a_market(
-            region_id: i64,
+            region_id: i64;
             page: i32
         ) -> Result<Vec<i64>, Error>
-        url = "{}/markets/{}/types?page={}";
+        url = "{}/markets/{}/types";
         label = "item type IDs with active market orders";
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -72,9 +72,20 @@ pub enum Error {
     ReqwestError(#[from] reqwest::Error),
     /// Errors related to parsing a URL for HTTP requests
     ///
+    /// This would occur if a URL for making an ESI request is
+    /// improperly formatted making it an invalid URL.
+    ///
     /// For a more detailed description, see [`url::ParseError`].
     #[error(transparent)]
     UrlParseError(#[from] url::ParseError),
+    /// Errors related to serializing or deserializing JSON data
+    ///
+    /// This would occur if there is an issue serializing a Rust type
+    /// to JSON for usage in URL query params for ESI endpoints.
+    ///
+    /// For a more detailed description, see [`serde_json::Error`].
+    #[error(transparent)]
+    SerdeJsonError(#[from] serde_json::Error),
 }
 
 /// Errors when building a new [`Client`](crate::Client) or [`Config`](crate::Config)

--- a/tests/endpoints/contacts.rs
+++ b/tests/endpoints/contacts.rs
@@ -58,7 +58,7 @@ authenticated_endpoint_test! {
         let contact_ids = vec![1,2,3];
         esi_client
             .contacts()
-            .delete_contacts(&access_token, contact_ids, character_id)
+            .delete_contacts(&access_token, character_id, contact_ids)
             .await
     },
     request_type = "DELETE",

--- a/tests/endpoints/contacts.rs
+++ b/tests/endpoints/contacts.rs
@@ -102,18 +102,18 @@ authenticated_endpoint_test! {
     add_contacts,
     |esi_client: eve_esi::Client, access_token: String | async move {
         let contact_ids = vec![1,2,3];
+        let character_id = 2114794365;
         let standing = -10.0;
         let label_ids = vec![1,2,3];
         let watched = false;
-        let character_id = 2114794365;
         esi_client
             .contacts()
-            .add_contacts(&access_token, contact_ids, standing, label_ids, watched, character_id)
+            .add_contacts(&access_token, contact_ids, character_id, standing, label_ids, watched)
             .await
     },
     request_type = "POST",
     // Note: label_ids array is percent encoded due to usage of URL serializer
-    url = "/characters/2114794365/contacts?standing=-10&label_ids=%5B1%2C2%2C3%5D&watched=false",
+    url = "/characters/2114794365/contacts?standing=-10.0&label_ids=%5B1%2C2%2C3%5D&watched=false",
     required_scopes = ScopeBuilder::new()
         .characters(CharactersScopes::new().write_contacts())
         .build();
@@ -124,18 +124,18 @@ authenticated_endpoint_test! {
     edit_contacts,
     |esi_client: eve_esi::Client, access_token: String | async move {
         let contact_ids = vec![1,2,3];
+        let character_id = 2114794365;
         let standing = -10.0;
         let label_ids = vec![1,2,3];
         let watched = false;
-        let character_id = 2114794365;
         esi_client
             .contacts()
-            .edit_contacts(&access_token, contact_ids, standing, label_ids, watched, character_id)
+            .edit_contacts(&access_token, contact_ids, character_id, standing, label_ids, watched)
             .await
     },
     request_type = "PUT",
     // Note: label_ids array is percent encoded due to usage of URL serializer
-    url = "/characters/2114794365/contacts?standing=-10&label_ids=%5B1%2C2%2C3%5D&watched=false",
+    url = "/characters/2114794365/contacts?standing=-10.0&label_ids=%5B1%2C2%2C3%5D&watched=false",
     required_scopes = ScopeBuilder::new()
         .characters(CharactersScopes::new().write_contacts())
         .build();

--- a/tests/endpoints/market.rs
+++ b/tests/endpoints/market.rs
@@ -270,7 +270,7 @@ public_endpoint_test! {
             .await
     },
     request_type = "GET",
-    url = "/markets/1/orders?order_type=all&page=1",
+    url = "/markets/1/orders?order_type=%22all%22&page=1",
     mock_response = serde_json::json!([
       {
         "duration": 0,


### PR DESCRIPTION
This refactor updates the functionality of the `define_endpoint!` macro to allow for defining both path parameters and query parameters for ESI endpoint request function arguments. 

This refactor additionally implements the usage of the `url` crate to parse ESI endpoint URLs and serialize query parameters for better correctness resulting in better stability. The values of query parameters are serialized via the usage of the `serde_json` crate. This is necessary in instances of `Vec<i32>` which cannot be serialized by default to a query parameter without converting it to a string with `serde_json` first. 

## `define_endpoint!` Usage Change

With this change, the usage of the `define_endpoint!` macro has changed to allow for the differentiation of path parameters and query parameters.

For example:

```
    define_endpoint! {
        auth_get list_historical_orders_by_a_character(
            // Access token required by all authenticated endpoints
            // Any additional requirements of the endpoint method, such as the body, would go here as well
            access_token: &str,
            // Path parameter of the character to fetch orders for
            character_id: i64;
            // Query parameter denoted by the usage of a `;` instead of a `comma` to demonstrate the start
            // of the query parameter arguments.
            page: i32
        ) -> Result<Vec<CharacterMarketOrder>, Error>
        // Path parameters are defined here, the first `{}` is the base ESI url, the following ones are the path parameter
        // arguments above
        // The query parameters will be appended to the URL as necessary for the request
        url = "{}/characters/{}/orders/history";
        label = "historical orders";
        required_scopes = ScopeBuilder::new().markets(MarketsScopes::new().read_character_orders()).build();
    }
```

## Performance Notes

It may be possible to obtain better performance here by only utilizing `serde_json` on Vec parameters but the performance difference would be negligible and may result in the necessity of custom handling of additional edge cases later on.

